### PR TITLE
Refactor import

### DIFF
--- a/src/Exceptions/ImportException.php
+++ b/src/Exceptions/ImportException.php
@@ -1,0 +1,13 @@
+<?php
+namespace abrain\Einsatzverwaltung\Exceptions;
+
+use Exception;
+
+/**
+ * Class ImportException
+ * @package abrain\Einsatzverwaltung\Exceptions
+ */
+class ImportException extends Exception
+{
+
+}

--- a/src/Exceptions/ImportPreparationException.php
+++ b/src/Exceptions/ImportPreparationException.php
@@ -1,0 +1,13 @@
+<?php
+namespace abrain\Einsatzverwaltung\Exceptions;
+
+use Exception;
+
+/**
+ * Class ImportPreparationException
+ * @package abrain\Einsatzverwaltung\Exceptions
+ */
+class ImportPreparationException extends Exception
+{
+
+}

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -1,7 +1,6 @@
 <?php
 namespace abrain\Einsatzverwaltung\Import;
 
-use abrain\Einsatzverwaltung\Core;
 use abrain\Einsatzverwaltung\Data;
 use abrain\Einsatzverwaltung\Import\Sources\AbstractSource;
 use abrain\Einsatzverwaltung\Model\IncidentReport;
@@ -21,11 +20,6 @@ class Helper
     private $utilities;
 
     /**
-     * @var Core
-     */
-    private $core;
-
-    /**
      * @var Options
      */
     private $options;
@@ -42,18 +36,15 @@ class Helper
     /**
      * Helper constructor.
      * @param Utilities $utilities
-     * @param Core $core
      * @param Options $options
      * @param Data $data
      */
-    public function __construct(Utilities $utilities, Core $core, Options $options, Data $data)
+    public function __construct(Utilities $utilities, Options $options, Data $data)
     {
         $this->utilities = $utilities;
-        $this->core = $core;
         $this->options = $options;
         $this->data = $data;
     }
-
 
     /**
      * Gibt ein Auswahlfeld zur Zuordnung der Felder in Einsatzverwaltung aus

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -332,6 +332,11 @@ class Helper
         if (array_key_exists('einsatz_mannschaft', $insertArgs['meta_input'])) {
             $insertArgs['meta_input']['einsatz_mannschaft'] = sanitize_text_field($insertArgs['meta_input']['einsatz_mannschaft']);
         }
+
+        // Berichte müssen explizit als 'nicht besonders' markiert werden
+        if (!array_key_exists('einsatz_special', $insertArgs['meta_input'])) {
+            $insertArgs['meta_input']['einsatz_special'] = '0';
+        }
     }
 
     /**

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -92,11 +92,20 @@ class Helper
             return strcmp($field1['label'], $field2['label']);
         });
         $string = '<select name="' . $parsedArgs['name'] . '">';
-        $string .= '<option value="-"' . ($parsedArgs['selected'] == '-' ? ' selected="selected"' : '') . '>';
-        $string .= 'nicht importieren' . '</option>';
+        /** @noinspection HtmlUnknownAttribute */
+        $string .= sprintf(
+            '<option value="-" %s>%s</option>',
+            selected($parsedArgs['selected'], '-', false),
+            'nicht importieren'
+        );
         foreach ($fields as $slug => $fieldProperties) {
-            $string .= '<option value="' . $slug . '"' . ($parsedArgs['selected'] == $slug ? ' selected="selected"' : '') . '>';
-            $string .= $fieldProperties['label'] . '</option>';
+            /** @noinspection HtmlUnknownAttribute */
+            $string .= sprintf(
+                '<option value="%s" %s>%s</option>',
+                esc_attr($slug),
+                selected($parsedArgs['selected'], $slug, false),
+                esc_html($fieldProperties['label'])
+            );
         }
         $string .= '</select>';
 

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -33,17 +33,17 @@ class Helper
     /**
      * @var array
      */
-    private $metaFields;
+    public $metaFields;
 
     /**
      * @var array
      */
-    private $postFields;
+    public $postFields;
 
     /**
      * @var array
      */
-    private $taxonomies;
+    public $taxonomies;
 
     /**
      * Helper constructor.
@@ -448,30 +448,6 @@ class Helper
 
         $this->utilities->printSuccess('Der Import ist abgeschlossen');
         echo '<a href="edit.php?post_type=einsatz">Zu den Einsatzberichten</a>';
-    }
-
-    /**
-     * @param array $metaFields
-     */
-    public function setMetaFields($metaFields)
-    {
-        $this->metaFields = $metaFields;
-    }
-
-    /**
-     * @param array $postFields
-     */
-    public function setPostFields($postFields)
-    {
-        $this->postFields = $postFields;
-    }
-
-    /**
-     * @param array $taxonomies
-     */
-    public function setTaxonomies($taxonomies)
-    {
-        $this->taxonomies = $taxonomies;
     }
 
     /**

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -7,7 +7,7 @@ use abrain\Einsatzverwaltung\Model\IncidentReport;
 use abrain\Einsatzverwaltung\Options;
 use abrain\Einsatzverwaltung\Utilities;
 use DateTime;
-use Error;
+use Exception;
 
 /**
  * Verschiedene Funktionen für den Import von Einsatzberichten
@@ -113,7 +113,7 @@ class Helper
         foreach ($termNames as $termName) {
             try {
                 $termIds[] = $this->getTermId($termName, $taxonomy);
-            } catch (Error $e) {
+            } catch (Exception $e) {
                 $this->utilities->printError($e->getMessage());
             }
         }
@@ -127,12 +127,12 @@ class Helper
      * @param string $termName
      * @param string $taxonomy
      * @return int
-     * @throws Error
+     * @throws Exception
      */
     public function getTermId($termName, $taxonomy)
     {
         if (is_taxonomy_hierarchical($taxonomy) === false) {
-            throw new Error("Die Taxonomie $taxonomy ist nicht hierarchisch!");
+            throw new Exception("Die Taxonomie $taxonomy ist nicht hierarchisch!");
         }
 
         $termName = trim($termName);
@@ -147,7 +147,7 @@ class Helper
         $newterm = wp_insert_term($termName, $taxonomy);
 
         if (is_wp_error($newterm)) {
-            throw new Error(sprintf(
+            throw new Exception(sprintf(
                 "Konnte %s '%s' nicht anlegen: %s",
                 $this->ownTerms[$taxonomy]['label'],
                 $termName,

--- a/src/Import/ImportStatus.php
+++ b/src/Import/ImportStatus.php
@@ -1,0 +1,39 @@
+<?php
+namespace abrain\Einsatzverwaltung\Import;
+
+require_once dirname(dirname(__FILE__)) . '/Util/ProgressTracker.php';
+
+use abrain\Einsatzverwaltung\Util\ProgressTracker;
+
+/**
+ * Class ImportStatus
+ * @package abrain\Einsatzverwaltung\Import
+ */
+class ImportStatus extends ProgressTracker
+{
+    private $postIds;
+
+    /**
+     * ImportStatus constructor.
+     * @param int $numReports
+     */
+    public function __construct($numReports)
+    {
+        parent::__construct($numReports);
+        $this->postIds = array();
+    }
+
+    /**
+     * @param int $postId
+     */
+    public function importSuccesss($postId)
+    {
+        $this->postIds[] = $postId;
+        $this->addStep();
+        $this->displayMessage(sprintf(
+            'Importiert: <a href="%s">%s</a>',
+            get_permalink($postId),
+            get_the_title($postId)
+        ));
+    }
+}

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -66,14 +66,11 @@ class Tool
     {
         $this->utilities = $utilities;
         $this->options = $options;
-        $this->addHooks();
-        $this->loadSources();
         $this->data = $data;
-    }
 
-    private function addHooks()
-    {
         add_action('admin_menu', array($this, 'addToolToMenu'));
+
+        $this->loadSources();
     }
 
     /**
@@ -193,10 +190,10 @@ class Tool
             }
         }
 
-        // Datums- und Zeitformat für CSV-Import übernehmen
+        // 'Sofort veröffentlichen'-Option übernehmen
         $this->currentSource->putArg(
-                'import_publish_reports',
-                $this->utilities->sanitizeCheckbox(array($_POST, 'import_publish_reports'))
+            'import_publish_reports',
+            $this->utilities->sanitizeCheckbox(array($_POST, 'import_publish_reports'))
         );
 
         echo "<h2>{$this->currentAction['name']}</h2>";
@@ -285,9 +282,6 @@ class Tool
 
         // Einsätze zählen
         $entries = $this->currentSource->getEntries(null);
-        if (false === $entries) {
-            return;
-        }
         if (empty($entries)) {
             $this->utilities->printWarning('Es wurden keine Eins&auml;tze gefunden.');
             return;
@@ -300,10 +294,6 @@ class Tool
 
         // Felder matchen
         echo "<h3>Felder zuordnen</h3>";
-        if (false === $this->nextAction) {
-            $this->utilities->printError('Keine Nachfolgeaktion gefunden!');
-            return;
-        }
 
         $this->helper->renderMatchForm($this->currentSource, array(
             'nonce_action' => $this->getNonceAction($this->currentSource, $this->nextAction['slug']),

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -2,6 +2,8 @@
 namespace abrain\Einsatzverwaltung\Import;
 
 use abrain\Einsatzverwaltung\Data;
+use abrain\Einsatzverwaltung\Exceptions\ImportException;
+use abrain\Einsatzverwaltung\Exceptions\ImportPreparationException;
 use abrain\Einsatzverwaltung\Import\Sources\AbstractSource;
 use abrain\Einsatzverwaltung\Import\Sources\Csv;
 use abrain\Einsatzverwaltung\Import\Sources\WpEinsatz;
@@ -339,9 +341,18 @@ class Tool
             return;
         }
 
+        require_once dirname(dirname(__FILE__)) . '/Exceptions/ImportException.php';
+        require_once dirname(dirname(__FILE__)) . '/Exceptions/ImportPreparationException.php';
+
         // Import starten
         echo '<p>Die Daten werden eingelesen, das kann einen Moment dauern.</p>';
-        $this->helper->import($this->currentSource, $mapping);
+        try {
+            $this->helper->import($this->currentSource, $mapping);
+        } catch (ImportException $e) {
+            $this->utilities->printError('Import abgebrochen, Ursache: ' . $e->getMessage());
+        } catch (ImportPreparationException $e) {
+            $this->utilities->printError('Importvorbereitung abgebrochen, Ursache: ' . $e->getMessage());
+        }
     }
 
     private function printDataNotice()

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -126,6 +126,9 @@ class Tool
     {
         require_once dirname(__FILE__) . '/Helper.php';
         $this->helper = new Helper($this->utilities, $this->options, $this->data);
+        $this->helper->setMetaFields(IncidentReport::getMetaFields());
+        $this->helper->setTaxonomies(IncidentReport::getTerms());
+        $this->helper->setPostFields(IncidentReport::getPostFields());
 
         echo '<div class="wrap">';
         echo '<h1>' . 'Einsatzberichte importieren' . '</h1>';

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -333,16 +333,24 @@ class Tool
 
         require_once dirname(dirname(__FILE__)) . '/Exceptions/ImportException.php';
         require_once dirname(dirname(__FILE__)) . '/Exceptions/ImportPreparationException.php';
+        require_once dirname(__FILE__) . '/ImportStatus.php';
 
         // Import starten
         echo '<p>Die Daten werden eingelesen, das kann einen Moment dauern.</p>';
         try {
-            $this->helper->import($this->currentSource, $mapping);
+            $importStatus = new ImportStatus(0);
+            $this->helper->import($this->currentSource, $mapping, $importStatus);
         } catch (ImportException $e) {
-            $this->utilities->printError('Import abgebrochen, Ursache: ' . $e->getMessage());
+            $importStatus->abort('Import abgebrochen, Ursache: ' . $e->getMessage());
+            return;
         } catch (ImportPreparationException $e) {
-            $this->utilities->printError('Importvorbereitung abgebrochen, Ursache: ' . $e->getMessage());
+            $importStatus->abort('Importvorbereitung abgebrochen, Ursache: ' . $e->getMessage());
+            return;
         }
+
+        $this->utilities->printSuccess('Der Import ist abgeschlossen');
+        $url = admin_url('edit.php?post_type=einsatz');
+        printf('<a href="%s">Zu den Einsatzberichten</a>', $url);
     }
 
     private function printDataNotice()

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -1,7 +1,6 @@
 <?php
 namespace abrain\Einsatzverwaltung\Import;
 
-use abrain\Einsatzverwaltung\Core;
 use abrain\Einsatzverwaltung\Data;
 use abrain\Einsatzverwaltung\Import\Sources\AbstractSource;
 use abrain\Einsatzverwaltung\Import\Sources\Csv;
@@ -45,11 +44,6 @@ class Tool
     private $utilities;
 
     /**
-     * @var Core
-     */
-    private $core;
-
-    /**
      * @var Options
      */
     private $options;
@@ -62,14 +56,12 @@ class Tool
     /**
      * Konstruktor
      *
-     * @param Core $core
      * @param Utilities $utilities
      * @param Options $options
      * @param Data $data
      */
-    public function __construct($core, $utilities, $options, $data)
+    public function __construct($utilities, $options, $data)
     {
-        $this->core = $core;
         $this->utilities = $utilities;
         $this->options = $options;
         $this->addHooks();
@@ -133,7 +125,7 @@ class Tool
     public function renderToolPage()
     {
         require_once dirname(__FILE__) . '/Helper.php';
-        $this->helper = new Helper($this->utilities, $this->core, $this->options, $this->data);
+        $this->helper = new Helper($this->utilities, $this->options, $this->data);
 
         echo '<div class="wrap">';
         echo '<h1>' . 'Einsatzberichte importieren' . '</h1>';

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -128,9 +128,9 @@ class Tool
     {
         require_once dirname(__FILE__) . '/Helper.php';
         $this->helper = new Helper($this->utilities, $this->options, $this->data);
-        $this->helper->setMetaFields(IncidentReport::getMetaFields());
-        $this->helper->setTaxonomies(IncidentReport::getTerms());
-        $this->helper->setPostFields(IncidentReport::getPostFields());
+        $this->helper->metaFields = IncidentReport::getMetaFields();
+        $this->helper->taxonomies = IncidentReport::getTerms();
+        $this->helper->postFields = IncidentReport::getPostFields();
 
         echo '<div class="wrap">';
         echo '<h1>' . 'Einsatzberichte importieren' . '</h1>';

--- a/src/Util/ProgressTracker.php
+++ b/src/Util/ProgressTracker.php
@@ -1,0 +1,92 @@
+<?php
+namespace abrain\Einsatzverwaltung\Util;
+
+use abrain\Einsatzverwaltung\Core;
+use abrain\Einsatzverwaltung\Utilities;
+
+/**
+ * Class ProgressTracker
+ * @package abrain\Einsatzverwaltung\Util
+ */
+class ProgressTracker
+{
+    /**
+     * @var int
+     */
+    public $currentStep;
+
+    /**
+     * @var int
+     */
+    public $totalSteps;
+
+    /**
+     * @var Utilities
+     */
+    protected $utilities;
+
+    /**
+     * ProgressTracker constructor.
+     * @param int $totalSteps
+     */
+    public function __construct($totalSteps = 0)
+    {
+        $this->utilities = Core::getInstance()->utilities;
+
+        $this->currentStep = 0;
+
+        if ($totalSteps < 0) {
+            $totalSteps = 0;
+        }
+        $this->totalSteps = $totalSteps;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function abort($message)
+    {
+        $this->utilities->printError($message);
+    }
+
+    public function addStep()
+    {
+        $this->currentStep += 1;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function displayMessage($message)
+    {
+        printf('<p>%s</p>', $message);
+    }
+
+    /**
+     * @param string $message
+     */
+    public function finish($message = '')
+    {
+        if ($this->totalSteps === 0) {
+            $this->totalSteps = 1;
+        }
+
+        $this->currentStep = $this->totalSteps;
+
+        if (!empty($message)) {
+            $this->utilities->printSuccess($message);
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getPercentage()
+    {
+        if ($this->totalSteps === 0) {
+            return 0;
+        }
+
+        return intval($this->currentStep * 100 / $this->totalSteps);
+    }
+}

--- a/src/einsatzverwaltung-core.php
+++ b/src/einsatzverwaltung-core.php
@@ -264,7 +264,7 @@ class Core
     /**
      * @var Options
      */
-    private $options;
+    public $options;
     
     /**
      * @var ImportTool
@@ -279,7 +279,7 @@ class Core
     /**
      * @var Utilities
      */
-    private $utilities;
+    public $utilities;
 
     /**
      * Constructor

--- a/src/einsatzverwaltung-core.php
+++ b/src/einsatzverwaltung-core.php
@@ -307,7 +307,7 @@ class Core
         $this->taxonomies = new Taxonomies($this->utilities);
 
         // Tools
-        $this->importTool = new ImportTool($this, $this->utilities, $this->options, $this->data);
+        $this->importTool = new ImportTool($this->utilities, $this->options, $this->data);
         $this->tasksPage = new TasksPage($this->utilities, $this->data);
 
         // Widgets

--- a/src/einsatzverwaltung-frontend.php
+++ b/src/einsatzverwaltung-frontend.php
@@ -345,6 +345,7 @@ class Frontend
                     'key' => 'einsatz_special',
                     'value' => '1'
                 );
+                // normale Beiträge haben diesen Metaeintrag nicht, sollen aber trotzdem angezeigt werden
                 $metaQuery[] = array(
                     'key' => 'einsatz_special',
                     'value' => '1',

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -24,7 +24,7 @@ class HelperTest extends \WP_UnitTestCase
         require_once dirname(dirname(dirname(__FILE__))) . '/src/Import/Helper.php';
 
         self::$core = Core::getInstance();
-        self::$helper = new Helper(self::$core->utilities, self::$core, self::$core->options, self::$core->getData());
+        self::$helper = new Helper(self::$core->utilities, self::$core->options, self::$core->getData());
 
         register_taxonomy('hierarchy', array(), array('hierarchical' => true));
         register_taxonomy('nohierarchy', array(), array('hierarchical' => false));

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -1,8 +1,8 @@
 <?php
-namespace abrain\Einsatzverwaltung;
+namespace abrain\Einsatzverwaltung\Import;
 
-use abrain\Einsatzverwaltung\Import\Helper;
-use Error;
+use abrain\Einsatzverwaltung\Core;
+use Exception;
 
 /**
  * Class HelperTest
@@ -81,7 +81,7 @@ class HelperTest extends \WP_UnitTestCase
 
         try {
             $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
-        } catch (Error $e) {
+        } catch (Exception $e) {
             $this->fail($e->getMessage());
             return;
         }
@@ -99,7 +99,7 @@ class HelperTest extends \WP_UnitTestCase
 
         try {
             $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
-        } catch (Error $e) {
+        } catch (Exception $e) {
             $this->fail($e->getMessage());
             return;
         }

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -188,7 +188,8 @@ class HelperTest extends \WP_UnitTestCase
         $insertArgs = array(
             'post_date' => '29.12.2017 18:24',
             'meta_input' => array(
-                'einsatz_einsatzende' => '2017/12-29 23 42'
+                'einsatz_einsatzende' => '2017/12-29 23 42',
+                'einsatz_special' => '1'
             ),
             'post_title' => 'Nr. 112 - Technische Hilfeleistung'
         );
@@ -227,9 +228,13 @@ class HelperTest extends \WP_UnitTestCase
         $this->assertArrayHasKey('meta_input', $insertArgs);
         $this->assertArrayHasKey('einsatz_einsatzende', $insertArgs['meta_input']);
         $this->assertEquals('2017-12-29 23:42', $insertArgs['meta_input']['einsatz_einsatzende']);
+
+        // Check that the special flag is still present
+        $this->assertArrayHasKey('einsatz_special', $insertArgs['meta_input']);
+        $this->assertEquals('1', $insertArgs['meta_input']['einsatz_special']);
     }
 
-    public function testDefaultTitle()
+    public function testDefaults()
     {
         $insertArgs = array(
             'post_date' => '29.12.2017 18:24',
@@ -252,5 +257,9 @@ class HelperTest extends \WP_UnitTestCase
         // The given post status should have been preserved
         $this->assertArrayHasKey('post_status', $insertArgs);
         $this->assertEquals($postStatus, $insertArgs['post_status']);
+
+        // Check that the special flag defaults to 0
+        $this->assertArrayHasKey('einsatz_special', $insertArgs['meta_input']);
+        $this->assertEquals('0', $insertArgs['meta_input']['einsatz_special']);
     }
 }

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -31,16 +31,16 @@ class HelperTest extends \WP_UnitTestCase
         register_taxonomy('nohierarchy', array(), array('hierarchical' => false));
         register_taxonomy('someTax', array(), array('hierarchical' => false));
 
-        self::$helper->setMetaFields(array('someMetaField' => array('label' => 'Some meta field')));
-        self::$helper->setPostFields(array(
+        self::$helper->metaFields = array('someMetaField' => array('label' => 'Some meta field'));
+        self::$helper->postFields = array(
             'somePostField' => array('label' => 'Some post field'),
             'anotherPostField' => array('label' => 'Another post field')
-        ));
-        self::$helper->setTaxonomies(array(
+        );
+        self::$helper->taxonomies = array(
             'hierarchy' => array('label' => 'Hierarchical taxonomy'),
             'nohierarchy' => array('label' => 'Non-hierarchical taxonomy'),
             'someTax' => array('label' => 'Another non-hierarchical taxonomy')
-        ));
+        );
 
         parent::setUpBeforeClass();
     }

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -2,8 +2,8 @@
 namespace abrain\Einsatzverwaltung\Import;
 
 use abrain\Einsatzverwaltung\Core;
+use abrain\Einsatzverwaltung\Exceptions\ImportPreparationException;
 use DateTime;
-use Exception;
 
 /**
  * Class HelperTest
@@ -51,7 +51,12 @@ class HelperTest extends \WP_UnitTestCase
     public function testGetTaxInputStringForNT()
     {
         $input = 'term1, term78, term99';
-        $result = self::$helper->getTaxInputString('nohierarchy', $input);
+        try {
+            $result = self::$helper->getTaxInputString('nohierarchy', $input);
+        } catch (ImportPreparationException $e) {
+            $this->fail($e->getMessage());
+            return;
+        }
         $this->assertEquals($input, $result);
     }
 
@@ -73,7 +78,12 @@ class HelperTest extends \WP_UnitTestCase
         $exitingId = $term['term_id'];
 
         $input = implode(',', $terms);
-        $result = self::$helper->getTaxInputString('hierarchy', $input);
+        try {
+            $result = self::$helper->getTaxInputString('hierarchy', $input);
+        } catch (ImportPreparationException $e) {
+            $this->fail($e->getMessage());
+            return;
+        }
         $returnedIds = explode(',', $result);
         $this->assertCount(count($terms), $returnedIds);
 
@@ -100,7 +110,7 @@ class HelperTest extends \WP_UnitTestCase
 
         try {
             $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
-        } catch (Exception $e) {
+        } catch (ImportPreparationException $e) {
             $this->fail($e->getMessage());
             return;
         }
@@ -118,7 +128,7 @@ class HelperTest extends \WP_UnitTestCase
 
         try {
             $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
-        } catch (Exception $e) {
+        } catch (ImportPreparationException $e) {
             $this->fail($e->getMessage());
             return;
         }
@@ -156,7 +166,11 @@ class HelperTest extends \WP_UnitTestCase
             'f6' => ''
         );
 
-        self::$helper->mapEntryToInsertArgs($mapping, $entry, $insertArgs);
+        try {
+            self::$helper->mapEntryToInsertArgs($mapping, $entry, $insertArgs);
+        } catch (ImportPreparationException $e) {
+            $this->fail($e->getMessage());
+        }
 
         // Check post fields
         $this->assertArrayHasKey('somePostField', $insertArgs);
@@ -197,7 +211,7 @@ class HelperTest extends \WP_UnitTestCase
             $postStatus = 'draft';
             $alarmzeit = DateTime::createFromFormat('d.m.Y H:i', $insertArgs['post_date']);
             self::$helper->prepareArgsForInsertPost($insertArgs, 'Y/m-d H i', $postStatus, $alarmzeit);
-        } catch (Exception $e) {
+        } catch (ImportPreparationException $e) {
             $this->fail($e->getMessage());
         }
 
@@ -246,7 +260,7 @@ class HelperTest extends \WP_UnitTestCase
             $postStatus = 'publish';
             $alarmzeit = DateTime::createFromFormat('d.m.Y H:i', $insertArgs['post_date']);
             self::$helper->prepareArgsForInsertPost($insertArgs, 'Y/m-d H i', $postStatus, $alarmzeit);
-        } catch (Exception $e) {
+        } catch (ImportPreparationException $e) {
             $this->fail($e->getMessage());
         }
 

--- a/tests/Import/HelperTest.php
+++ b/tests/Import/HelperTest.php
@@ -1,0 +1,115 @@
+<?php
+namespace abrain\Einsatzverwaltung;
+
+use abrain\Einsatzverwaltung\Import\Helper;
+use Error;
+
+/**
+ * Class HelperTest
+ * @package abrain\Einsatzverwaltung
+ */
+class HelperTest extends \WP_UnitTestCase
+{
+    /** @var Core */
+    private static $core;
+
+    /** @var Helper */
+    private static $helper;
+
+    /**
+     * @inheritDoc
+     */
+    public static function setUpBeforeClass()
+    {
+        require_once dirname(dirname(dirname(__FILE__))) . '/src/Import/Helper.php';
+
+        self::$core = Core::getInstance();
+        self::$helper = new Helper(self::$core->utilities, self::$core, self::$core->options, self::$core->getData());
+
+        register_taxonomy('hierarchy', array(), array('hierarchical' => true));
+        register_taxonomy('nohierarchy', array(), array('hierarchical' => false));
+
+        parent::setUpBeforeClass();
+    }
+
+    public function testGetTaxInputStringForNT()
+    {
+        $input = 'term1, term78, term99';
+        $result = self::$helper->getTaxInputString('nohierarchy', $input);
+        $this->assertEquals($input, $result);
+    }
+
+    public function testGetTaxInputStringForHT()
+    {
+        $terms = array('hterm6', 'hterm123', 'hterm777');
+
+        // Check that the terms do not exist yet
+        foreach ($terms as $term) {
+            $this->assertFalse(get_term_by('name', $term, 'hierarchy'));
+        }
+
+        // Create one upfront
+        $term = wp_insert_term($terms[0], 'hierarchy');
+        $this->assertInternalType('array', $term);
+        $exitingId = $term['term_id'];
+
+        $input = implode(',', $terms);
+        $result = self::$helper->getTaxInputString('hierarchy', $input);
+        $returnedIds = explode(',', $result);
+        $this->assertCount(count($terms), $returnedIds);
+
+        // Check that the existing term was reused
+        $this->assertContains($exitingId, $returnedIds);
+
+        // Check that the terms have been created
+        $names = array();
+        foreach ($returnedIds as $id) {
+            $wpterm = get_term_by('id', $id, 'hierarchy');
+            $this->assertNotFalse($wpterm);
+            $names[] = $wpterm->name;
+        }
+
+        $this->assertEquals($names, $terms);
+    }
+
+    public function testGetExistingTermId()
+    {
+        // Make sure term exists
+        $termName = 'existingTerm';
+        $term = wp_insert_term($termName, 'hierarchy');
+        $this->assertInternalType('array', $term);
+
+        try {
+            $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
+        } catch (Error $e) {
+            $this->fail($e->getMessage());
+            return;
+        }
+
+        $this->assertEquals($term['term_id'], $returnedTermId);
+    }
+
+    public function testGetUnknownTermId()
+    {
+        $termName = 'unknownTerm';
+
+        // Make sure term does not exist
+        $wpterm = get_term_by('name', $termName, 'hierarchy');
+        $this->assertFalse($wpterm);
+
+        try {
+            $returnedTermId = self::$helper->getTermId($termName, 'hierarchy');
+        } catch (Error $e) {
+            $this->fail($e->getMessage());
+            return;
+        }
+
+        // Term should have been created
+        $wpterm = get_term_by('name', $termName, 'hierarchy');
+        $this->assertNotFalse($wpterm);
+
+        $termId = $wpterm->term_id;
+        $this->assertEquals($termId, $returnedTermId);
+        $this->assertNotEquals($termId, $termName);
+    }
+}

--- a/tests/Util/ProgressTrackerTest.php
+++ b/tests/Util/ProgressTrackerTest.php
@@ -1,0 +1,88 @@
+<?php
+namespace abrain\Einsatzverwaltung\Util;
+
+/**
+ * Class ProgressTrackerTest
+ * @package abrain\Einsatzverwaltung\Util
+ */
+class ProgressTrackerTest extends \WP_UnitTestCase
+{
+    public function testAddStep()
+    {
+        $progressTracker = new ProgressTracker();
+        $this->assertEquals(0, $progressTracker->currentStep);
+        $progressTracker->addStep();
+        $this->assertEquals(1, $progressTracker->currentStep);
+        $progressTracker->addStep();
+        $progressTracker->addStep();
+        $this->assertEquals(3, $progressTracker->currentStep);
+    }
+
+    public function testGetPercentage()
+    {
+        $progressTracker = new ProgressTracker(6);
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $this->assertEquals(16, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $progressTracker->addStep();
+        $this->assertEquals(50, $progressTracker->getPercentage());
+    }
+
+    public function testGetPercentageUnspecifiedTotal()
+    {
+        $progressTracker = new ProgressTracker();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $progressTracker->addStep();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+    }
+
+    public function testPercentageNegativeTotalSteps()
+    {
+        $progressTracker = new ProgressTracker(-5);
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->addStep();
+        $progressTracker->addStep();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+    }
+
+    public function testFinish()
+    {
+        $progressTracker = new ProgressTracker(4);
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $this->expectOutputRegex('/Test message for finish method/');
+        $progressTracker->finish('Test message for finish method');
+        $this->assertEquals(100, $progressTracker->getPercentage());
+    }
+
+    public function testFinishUnspecifiedTotal()
+    {
+        $progressTracker = new ProgressTracker();
+        $this->assertEquals(0, $progressTracker->getPercentage());
+        $progressTracker->finish();
+        $this->assertEquals(100, $progressTracker->getPercentage());
+    }
+
+    public function testDisplayMessage()
+    {
+        $progressTracker = new ProgressTracker();
+        $this->expectOutputRegex('/Some test message/');
+        $progressTracker->displayMessage('Some test message');
+    }
+
+    public function testAbort()
+    {
+        $progressTracker = new ProgressTracker(9);
+        $progressTracker->addStep();
+        $progressTracker->addStep();
+        $this->assertEquals(22, $progressTracker->getPercentage());
+        $this->expectOutputRegex('/Some message about a failure/');
+        $progressTracker->abort('Some message about a failure');
+        $this->assertEquals(22, $progressTracker->getPercentage());
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,9 @@ tests_add_filter('muplugins_loaded', function () {
     // DB-Version setzen, damit der Upgrade-Prozess nicht unnötig anläuft
     // Wird normal bei der Aktivierung des Plugins gemacht, aber diese Action wird bei den Tests nicht aufgerufen
     add_option('einsatzvw_db_version', \abrain\Einsatzverwaltung\Core::DB_VERSION);
+
+    // Zeitzone setzen
+    update_option('timezone_string', 'Europe/Berlin');
 });
 
 require $_tests_dir . '/includes/bootstrap.php';


### PR DESCRIPTION
Der Import-Vorgang wurde in kleinere Methoden aufgeteilt, was für mehr Übersichtlichkeit und Testbarkeit sorgen soll.