### PR TITLE
Einheiten

### DIFF
--- a/src/Admin/Initializer.php
+++ b/src/Admin/Initializer.php
@@ -44,6 +44,9 @@ class Initializer
         $reportEditScreen = new ReportEditScreen();
         add_action('add_meta_boxes_einsatz', array($reportEditScreen, 'addMetaBoxes'));
 
+        $unitEditScreen = new UnitEditScreen();
+        add_filter('default_hidden_meta_boxes', array($unitEditScreen, 'filterDefaultHiddenMetaboxes'), 10, 2);
+
         // Register Settings
         $mainPage = new MainPage($options, $permalinkController);
         add_action('admin_menu', array($mainPage, 'addToSettingsMenu'));

--- a/src/Admin/ReportEditScreen.php
+++ b/src/Admin/ReportEditScreen.php
@@ -198,7 +198,10 @@ class ReportEditScreen
             return;
         }
 
-        $assignedUnits = get_post_meta($post->ID, '_evw_unit');
+        $report = new IncidentReport($post);
+        $assignedUnits = array_map(function (WP_Post $unit) {
+            return $unit->ID;
+        }, $report->getUnits());
         echo '<div><ul>';
         foreach ($units as $unit) {
             $assigned = in_array($unit->ID, $assignedUnits);

--- a/src/Admin/ReportEditScreen.php
+++ b/src/Admin/ReportEditScreen.php
@@ -2,6 +2,7 @@
 namespace abrain\Einsatzverwaltung\Admin;
 
 use abrain\Einsatzverwaltung\Model\IncidentReport;
+use abrain\Einsatzverwaltung\Types\Unit;
 use WP_Post;
 use wpdb;
 
@@ -44,6 +45,18 @@ class ReportEditScreen
             'einsatzartdiv',
             'Einsatzart',
             array('abrain\Einsatzverwaltung\Admin\ReportEditScreen', 'displayMetaBoxEinsatzart'),
+            'einsatz',
+            'side',
+            'default',
+            array(
+                '__block_editor_compatible_meta_box' => true,
+                '__back_compat_meta_box' => false
+            )
+        );
+        add_meta_box(
+            'einsatzverwaltung_units',
+            __('Units', 'einsatzverwaltung'),
+            array($this, 'displayMetaBoxUnits'),
             'einsatz',
             'side',
             'default',
@@ -166,6 +179,37 @@ class ReportEditScreen
         $report = new IncidentReport($post);
         $typeOfIncident = $report->getTypeOfIncident();
         self::dropdownEinsatzart($typeOfIncident ? $typeOfIncident->term_id : 0);
+    }
+
+    /**
+     * @param WP_Post $post
+     */
+    public function displayMetaBoxUnits(WP_Post $post)
+    {
+        $units = get_posts(array(
+            'post_type' => Unit::POST_TYPE,
+            'numberposts' => -1,
+            'order' => 'ASC',
+            'orderby' => 'name'
+        ));
+        if (empty($units)) {
+            $postTypeObject = get_post_type_object(Unit::POST_TYPE);
+            printf("<div>%s</div>", esc_html($postTypeObject->labels->not_found));
+            return;
+        }
+
+        $assignedUnits = get_post_meta($post->ID, '_evw_unit');
+        echo '<div><ul>';
+        foreach ($units as $unit) {
+            $assigned = in_array($unit->ID, $assignedUnits);
+            printf(
+                '<li><label><input type="checkbox" name="evw_units[]" value="%d"%s>%s</label></li>',
+                esc_attr($unit->ID),
+                checked($assigned, true, false),
+                esc_html($unit->post_title)
+            );
+        }
+        echo '</ul></div>';
     }
 
     /**

--- a/src/Admin/ReportListTable.php
+++ b/src/Admin/ReportListTable.php
@@ -32,6 +32,7 @@ class ReportListTable
         $columns['e_alarmzeit'] = 'Alarmzeit';
         $columns['e_einsatzende'] = 'Einsatzende';
         $columns['e_art'] = 'Art';
+        $columns['einsatzverwaltung_units'] = __('Units', 'einsatzverwaltung');
         $columns['e_fzg'] = 'Fahrzeuge';
 
         return $columns;
@@ -84,6 +85,9 @@ class ReportListTable
                 return join(', ', $vehicleLinks);
             case 'einsatzverwaltung_annotations':
                 return AnnotationIconBar::getInstance()->render($report);
+            case 'einsatzverwaltung_units':
+                $unitNames = array_map('get_the_title', $report->getUnits());
+                return join(', ', $unitNames);
         }
 
         return '';

--- a/src/Admin/UnitEditScreen.php
+++ b/src/Admin/UnitEditScreen.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace abrain\Einsatzverwaltung\Admin;
+
+use abrain\Einsatzverwaltung\Types\Unit;
+use WP_Screen;
+
+/**
+ * Class UnitEditScreen
+ * @package abrain\Einsatzverwaltung\Admin
+ */
+class UnitEditScreen
+{
+    /**
+     * @param string[] $hidden
+     * @param WP_Screen $screen
+     *
+     * @return string[]
+     */
+    public function filterDefaultHiddenMetaboxes($hidden, WP_Screen $screen)
+    {
+        if ($screen->post_type !== Unit::POST_TYPE) {
+            return $hidden;
+        }
+
+        $hidden[] = 'postcustom';
+        return $hidden;
+    }
+}

--- a/src/Data.php
+++ b/src/Data.php
@@ -172,6 +172,19 @@ class Data
         remove_action('save_post_einsatz', array($this, 'savePostdata'));
         wp_update_post($updateArgs);
         add_action('save_post_einsatz', array($this, 'savePostdata'), 10, 2);
+
+        // Save Units
+        $units = (array) filter_input(INPUT_POST, 'evw_units', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY);
+        $assignedUnits = get_post_meta($post->ID, '_evw_unit');
+        $unitsToAdd = array_diff($units, $assignedUnits);
+        $unitsToDelete = array_diff($assignedUnits, $units);
+
+        foreach ($unitsToDelete as $unitId) {
+            delete_post_meta($post->ID, '_evw_unit', $unitId);
+        }
+        foreach ($unitsToAdd as $unitId) {
+            add_post_meta($post->ID, '_evw_unit', $unitId);
+        }
     }
 
     /**

--- a/src/Frontend/ReportList.php
+++ b/src/Frontend/ReportList.php
@@ -54,7 +54,7 @@ class ReportList
     /**
      * Generiert den HTML-Code für die Liste
      *
-     * @param array $reports Eine Liste von IncidentReport-Objekten
+     * @param IncidentReport[] $reports Eine Liste von IncidentReport-Objekten
      * @param ReportListParameters $parameters
      */
     private function constructList($reports, ReportListParameters $parameters)
@@ -78,7 +78,6 @@ class ReportList
             $this->beginTable(false, $parameters);
             $this->insertTableHeader($parameters);
         }
-        /** @var IncidentReport $report */
         foreach ($reports as $report) {
             $timeOfAlerting = $report->getTimeOfAlerting();
             $currentYear = intval($timeOfAlerting->format('Y'));
@@ -125,7 +124,7 @@ class ReportList
     /**
      * Gibt den HTML-Code für die Liste zurück
      *
-     * @param array $reports Eine Liste von IncidentReport-Objekten
+     * @param IncidentReport[] $reports Eine Liste von IncidentReport-Objekten
      * @param ReportListParameters $parameters
      *
      * @return string HTML-Code der Liste
@@ -138,7 +137,7 @@ class ReportList
     }
 
     /**
-     * @param array $reports Eine Liste von IncidentReport-Objekten
+     * @param IncidentReport[] $reports Eine Liste von IncidentReport-Objekten
      * @param ReportListParameters $parameters
      */
     public function printList($reports, ReportListParameters $parameters)

--- a/src/Frontend/ReportList.php
+++ b/src/Frontend/ReportList.php
@@ -22,7 +22,7 @@ class ReportList
      * @var array
      */
     private $columnsLinkBlacklist = array('incidentCommander', 'location', 'vehicles', 'alarmType', 'additionalForces',
-        'incidentType');
+        'incidentType', 'units');
 
     /**
      * @var Formatter
@@ -315,6 +315,9 @@ class ReportList
             case 'additionalForces':
                 $cellContent = $this->formatter->getAdditionalForces($report, $parameters->linkAdditionalForces, false);
                 break;
+            case 'units':
+                $cellContent = $this->formatter->getUnits($report);
+                break;
             case 'incidentType':
                 $showHierarchy = (get_option('einsatzvw_list_art_hierarchy', '0') === '1');
                 $cellContent = $this->formatter->getTypeOfIncident($report, false, false, $showHierarchy);
@@ -391,6 +394,9 @@ class ReportList
             'additionalForces' => array(
                 'name' => 'Weitere Kr&auml;fte',
                 'cssname' => 'Weitere Kr\0000E4fte',
+            ),
+            'units' => array(
+                'name' => __('Units', 'einsatzverwaltung')
             ),
             'incidentType' => array(
                 'name' => 'Einsatzart'

--- a/src/Model/IncidentReport.php
+++ b/src/Model/IncidentReport.php
@@ -348,6 +348,15 @@ class IncidentReport
     }
 
     /**
+     * @return WP_Post[]
+     */
+    public function getUnits()
+    {
+        $unitIds = get_post_meta($this->getPostId(), '_evw_unit');
+        return array_map('get_post', $unitIds);
+    }
+
+    /**
      * Gibt die Fahrzeuge eines Einsatzberichts aus
      *
      * @return WP_Term[]

--- a/src/ReportQuery.php
+++ b/src/ReportQuery.php
@@ -128,7 +128,7 @@ class ReportQuery
     }
 
     /**
-     * @return array
+     * @return IncidentReport[]
      */
     public function getReports()
     {

--- a/src/ReportQuery.php
+++ b/src/ReportQuery.php
@@ -52,6 +52,11 @@ class ReportQuery
     private $orderAsc;
 
     /**
+     * @var int[]
+     */
+    private $units;
+
+    /**
      * @var int
      */
     private $year;
@@ -109,6 +114,14 @@ class ReportQuery
 
         if ($this->onlySpecialReports) {
             $metaQuery[] = array('key' => 'einsatz_special', 'value' => '1');
+        }
+
+        if (!empty($this->units)) {
+            $unitSubQuery = array('relation' => 'OR');
+            foreach ($this->units as $unit) {
+                $unitSubQuery[] = array('key' => '_evw_unit', 'value' => $unit);
+            }
+            $metaQuery[] = $unitSubQuery;
         }
 
         return $metaQuery;
@@ -208,6 +221,14 @@ class ReportQuery
     public function setOrderAsc($orderAsc)
     {
         $this->orderAsc = $orderAsc;
+    }
+
+    /**
+     * @param int[] $units
+     */
+    public function setUnits($units)
+    {
+        $this->units = $units;
     }
 
     /**

--- a/src/Shortcodes/ReportList.php
+++ b/src/Shortcodes/ReportList.php
@@ -37,6 +37,7 @@ class ReportList
             'link' => 'title',
             'limit' => -1,
             'einsatzart' => 0,
+            'units' => '',
             'options' => ''
         );
     }
@@ -116,6 +117,13 @@ class ReportList
 
         if (array_key_exists('einsatzart', $attributes) && is_numeric($attributes['einsatzart'])) {
             $reportQuery->setIncidentTypeId(intval($attributes['einsatzart']));
+        }
+
+        if (array_key_exists('units', $attributes)) {
+            $unitIds = explode(',', $attributes['units']);
+            $unitIds = array_map('trim', $unitIds);
+            $unitIds = array_filter($unitIds, 'is_numeric');
+            $reportQuery->setUnits(array_map('intval', $unitIds));
         }
     }
 }

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -8,6 +8,7 @@ use abrain\Einsatzverwaltung\Types\CustomTaxonomy;
 use abrain\Einsatzverwaltung\Types\ExtEinsatzmittel;
 use abrain\Einsatzverwaltung\Types\IncidentType;
 use abrain\Einsatzverwaltung\Types\Report;
+use abrain\Einsatzverwaltung\Types\Unit;
 use abrain\Einsatzverwaltung\Types\Vehicle;
 
 /**
@@ -48,6 +49,9 @@ class TypeRegistry
         $this->registerTaxonomy(new Vehicle(), $report->getSlug());
         $this->registerTaxonomy(new ExtEinsatzmittel(), $report->getSlug());
         $this->registerTaxonomy(new Alarmierungsart(), $report->getSlug());
+
+        $unit = new Unit();
+        $this->registerPostType($unit);
 
         $permalinkController->addRewriteRules($report);
     }

--- a/src/TypeRegistry.php
+++ b/src/TypeRegistry.php
@@ -3,7 +3,8 @@ namespace abrain\Einsatzverwaltung;
 
 use abrain\Einsatzverwaltung\Exceptions\TypeRegistrationException;
 use abrain\Einsatzverwaltung\Types\Alarmierungsart;
-use abrain\Einsatzverwaltung\Types\CustomType;
+use abrain\Einsatzverwaltung\Types\CustomPostType;
+use abrain\Einsatzverwaltung\Types\CustomTaxonomy;
 use abrain\Einsatzverwaltung\Types\ExtEinsatzmittel;
 use abrain\Einsatzverwaltung\Types\IncidentType;
 use abrain\Einsatzverwaltung\Types\Report;
@@ -54,19 +55,20 @@ class TypeRegistry
     /**
      * Registers a custom post type
      *
-     * @param CustomType $customType Object that describes the custom post type
+     * @param CustomPostType $customPostType Object that describes the custom post type
+     *
      * @throws TypeRegistrationException
      */
-    private function registerPostType(CustomType $customType)
+    private function registerPostType(CustomPostType $customPostType)
     {
-        $slug = $customType->getSlug();
+        $slug = $customPostType->getSlug();
         if (array_key_exists($slug, $this->postTypes)) {
             throw new TypeRegistrationException(
                 sprintf(__('Post type with slug "%s" already exists', 'einsatzverwaltung'), $slug)
             );
         }
 
-        $postType = register_post_type($slug, $customType->getRegistrationArgs());
+        $postType = register_post_type($slug, $customPostType->getRegistrationArgs());
         if (is_wp_error($postType)) {
             throw new TypeRegistrationException(sprintf(
                 __('Failed to register post type with slug "%s": %s', 'einsatzverwaltung'),
@@ -75,8 +77,8 @@ class TypeRegistry
             ));
         }
 
-        $customType->registerCustomFields($this->taxonomyCustomFields);
-        $customType->registerHooks();
+        $customPostType->registerCustomFields();
+        $customPostType->registerHooks();
 
         $this->postTypes[$slug] = $postType;
     }
@@ -84,11 +86,12 @@ class TypeRegistry
     /**
      * Registers a custom taxonomy for a certain post type
      *
-     * @param CustomType $customTaxonomy Object that describes the custom taxonomy
+     * @param CustomTaxonomy $customTaxonomy Object that describes the custom taxonomy
      * @param string $postType
+     *
      * @throws TypeRegistrationException
      */
-    private function registerTaxonomy(CustomType $customTaxonomy, $postType)
+    private function registerTaxonomy(CustomTaxonomy $customTaxonomy, $postType)
     {
         $slug = $customTaxonomy->getSlug();
         if (get_taxonomy($slug) !== false) {

--- a/src/Types/Alarmierungsart.php
+++ b/src/Types/Alarmierungsart.php
@@ -7,7 +7,7 @@ use abrain\Einsatzverwaltung\TaxonomyCustomFields;
  * Description of the custom taxonomy 'Alarmierungsart'
  * @package abrain\Einsatzverwaltung\Types
  */
-class Alarmierungsart implements CustomType
+class Alarmierungsart implements CustomTaxonomy
 {
     /**
      * @return string

--- a/src/Types/CustomPostType.php
+++ b/src/Types/CustomPostType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace abrain\Einsatzverwaltung\Types;
+
+/**
+ * Interface CustomPostType
+ * @package abrain\Einsatzverwaltung\Types
+ */
+interface CustomPostType extends CustomType
+{
+    /**
+     * @return void
+     */
+    public function registerCustomFields();
+}

--- a/src/Types/CustomTaxonomy.php
+++ b/src/Types/CustomTaxonomy.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace abrain\Einsatzverwaltung\Types;
+
+use abrain\Einsatzverwaltung\TaxonomyCustomFields;
+
+/**
+ * Interface CustomTaxonomy
+ * @package abrain\Einsatzverwaltung\Types
+ */
+interface CustomTaxonomy extends CustomType
+{
+    /**
+     * @param TaxonomyCustomFields $taxonomyCustomFields
+     *
+     * @return void
+     */
+    public function registerCustomFields(TaxonomyCustomFields $taxonomyCustomFields);
+}

--- a/src/Types/CustomType.php
+++ b/src/Types/CustomType.php
@@ -1,8 +1,6 @@
 <?php
 namespace abrain\Einsatzverwaltung\Types;
 
-use abrain\Einsatzverwaltung\TaxonomyCustomFields;
-
 /**
  * Interface CustomType
  * @package abrain\Einsatzverwaltung\Types
@@ -18,12 +16,6 @@ interface CustomType
      * @return array
      */
     public function getRegistrationArgs();
-
-    /**
-     * @param TaxonomyCustomFields $taxonomyCustomFields
-     * @return void
-     */
-    public function registerCustomFields(TaxonomyCustomFields $taxonomyCustomFields);
 
     /**
      * @return void

--- a/src/Types/ExtEinsatzmittel.php
+++ b/src/Types/ExtEinsatzmittel.php
@@ -8,7 +8,7 @@ use abrain\Einsatzverwaltung\TaxonomyCustomFields;
  * Description of the custom taxonomy 'Externes Einsatzmittel'
  * @package abrain\Einsatzverwaltung\Types
  */
-class ExtEinsatzmittel implements CustomType
+class ExtEinsatzmittel implements CustomTaxonomy
 {
     /**
      * @return string

--- a/src/Types/IncidentType.php
+++ b/src/Types/IncidentType.php
@@ -9,7 +9,7 @@ use WP_REST_Response;
  * Description of the custom taxonomy 'Type of incident'
  * @package abrain\Einsatzverwaltung\Types
  */
-class IncidentType implements CustomType
+class IncidentType implements CustomTaxonomy
 {
     /**
      * @return string

--- a/src/Types/Report.php
+++ b/src/Types/Report.php
@@ -3,13 +3,12 @@ namespace abrain\Einsatzverwaltung\Types;
 
 use abrain\Einsatzverwaltung\Model\ReportAnnotation;
 use abrain\Einsatzverwaltung\ReportAnnotationRepository;
-use abrain\Einsatzverwaltung\TaxonomyCustomFields;
 
 /**
  * Description of the custom post type for the reports
  * @package abrain\Einsatzverwaltung\Types
  */
-class Report implements CustomType
+class Report implements CustomPostType
 {
     const DEFAULT_REWRITE_SLUG = 'einsatzberichte';
     const SLUG = 'einsatz';
@@ -153,7 +152,7 @@ class Report implements CustomType
     /**
      * @inheritdoc
      */
-    public function registerCustomFields(TaxonomyCustomFields $taxonomyCustomFields)
+    public function registerCustomFields()
     {
         $this->registerPostMeta();
         $this->registerAnnotations();

--- a/src/Types/Unit.php
+++ b/src/Types/Unit.php
@@ -60,6 +60,7 @@ class Unit implements CustomPostType
             'show_in_admin_bar' => false,
             'show_in_rest' => true,
             'capability_type' => $this->getSlug(),
+            'map_meta_cap' => true,
             'menu_icon' => 'dashicons-networking',
         );
     }

--- a/src/Types/Unit.php
+++ b/src/Types/Unit.php
@@ -1,0 +1,86 @@
+<?php
+namespace abrain\Einsatzverwaltung\Types;
+
+/**
+ * Description of the custom post type for units
+ * @package abrain\Einsatzverwaltung\Types
+ */
+class Unit implements CustomPostType
+{
+    /**
+     * @return array
+     */
+    private function getLabels()
+    {
+        return array(
+            'name' => _x('Units', 'post type general name', 'einsatzverwaltung'),
+            'singular_name' => _x('Unit', 'post type singular name', 'einsatzverwaltung'),
+            'menu_name' => __('Units', 'einsatzverwaltung'),
+            'add_new' => _x('Add New', 'Unit', 'einsatzverwaltung'),
+            'add_new_item' => __('Add New Unit', 'einsatzverwaltung'),
+            'edit_item' => __('Edit Unit', 'einsatzverwaltung'),
+            'new_item' => __('New Unit', 'einsatzverwaltung'),
+            'view_item' => __('View Unit', 'einsatzverwaltung'),
+            'view_items' => __('View Units', 'einsatzverwaltung'),
+            'search_items' => __('Search Units', 'einsatzverwaltung'),
+            'not_found' => __('No units found.', 'einsatzverwaltung'),
+            'not_found_in_trash' => __('No units found in Trash.', 'einsatzverwaltung'),
+            'archives' => __('Unit Archives', 'einsatzverwaltung'),
+            'attributes' => __('Unit Attributes', 'einsatzverwaltung'),
+            'insert_into_item' => __('Insert into unit', 'einsatzverwaltung'),
+            'uploaded_to_this_item' => __('Uploaded to this unit', 'einsatzverwaltung'),
+            'featured_image' => _x('Featured Image', 'unit', 'einsatzverwaltung'),
+            'set_featured_image' => __('Set featured image', 'unit', 'einsatzverwaltung'),
+            'remove_featured_image' => _x('Remove featured image', 'unit', 'einsatzverwaltung'),
+            'use_featured_image' => _x('Use as featured image', 'unit', 'einsatzverwaltung'),
+            'filter_items_list' => __('Filter units list', 'einsatzverwaltung'),
+            'items_list_navigation' => __('Units list navigation', 'einsatzverwaltung'),
+            'items_list' => __('Units list', 'einsatzverwaltung'),
+            'item_published' => __('Unit published.', 'einsatzverwaltung'),
+            'item_published_privately' => __('Unit published privately.', 'einsatzverwaltung'),
+            'item_reverted_to_draft' => __('Unit reverted to draft.', 'einsatzverwaltung'),
+            'item_scheduled' => __('Unit scheduled.', 'einsatzverwaltung'),
+            'item_updated' => __('Unit updated.', 'einsatzverwaltung'),
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public function getRegistrationArgs()
+    {
+        return array(
+            'labels' => $this->getLabels(),
+            'public' => false,
+            'supports' => array('title', 'editor', 'thumbnail', 'revisions', 'custom-fields'),
+            'show_ui' => true,
+            'show_in_menu' => 'edit.php?post_type=' . Report::SLUG,
+            'show_in_admin_bar' => false,
+            'show_in_rest' => true,
+            'capability_type' => $this->getSlug(),
+            'menu_icon' => 'dashicons-networking',
+        );
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug()
+    {
+        return 'evw_unit';
+    }
+
+    /**
+     * @return void
+     */
+    public function registerCustomFields()
+    {
+    }
+
+    /**
+     * @return void
+     */
+    public function registerHooks()
+    {
+    }
+}

--- a/src/Types/Unit.php
+++ b/src/Types/Unit.php
@@ -7,6 +7,8 @@ namespace abrain\Einsatzverwaltung\Types;
  */
 class Unit implements CustomPostType
 {
+    const POST_TYPE = 'evw_unit';
+
     /**
      * @return array
      */
@@ -67,7 +69,7 @@ class Unit implements CustomPostType
      */
     public function getSlug()
     {
-        return 'evw_unit';
+        return self::POST_TYPE;
     }
 
     /**

--- a/src/Types/Unit.php
+++ b/src/Types/Unit.php
@@ -58,7 +58,7 @@ class Unit implements CustomPostType
             'show_ui' => true,
             'show_in_menu' => 'edit.php?post_type=' . Report::SLUG,
             'show_in_admin_bar' => false,
-            'show_in_rest' => true,
+            'show_in_rest' => false,
             'capability_type' => $this->getSlug(),
             'map_meta_cap' => true,
             'menu_icon' => 'dashicons-networking',

--- a/src/Types/Vehicle.php
+++ b/src/Types/Vehicle.php
@@ -9,7 +9,7 @@ use abrain\Einsatzverwaltung\TaxonomyCustomFields;
  * Description of the custom taxonomy 'Vehicle'
  * @package abrain\Einsatzverwaltung\Types
  */
-class Vehicle implements CustomType
+class Vehicle implements CustomTaxonomy
 {
     /**
      * @return string

--- a/src/Types/Vehicle.php
+++ b/src/Types/Vehicle.php
@@ -4,6 +4,7 @@ namespace abrain\Einsatzverwaltung\Types;
 use abrain\Einsatzverwaltung\CustomFields\NumberInput;
 use abrain\Einsatzverwaltung\CustomFields\PostSelector;
 use abrain\Einsatzverwaltung\TaxonomyCustomFields;
+use WP_Term;
 
 /**
  * Description of the custom taxonomy 'Vehicle'
@@ -82,5 +83,55 @@ class Vehicle implements CustomTaxonomy
      */
     public function registerHooks()
     {
+        add_action("{$this->getSlug()}_pre_add_form", array($this, 'deprectatedHierarchyNotice'));
+        add_action('admin_menu', array($this, 'addBadgeToMenu'));
+    }
+
+    /**
+     * Check if there are vehicles with parents, as that is now deprecated
+     */
+    public function deprectatedHierarchyNotice()
+    {
+        $termsWithParentCount = $this->getTermsWithParentCount();
+        if ($termsWithParentCount > 0) {
+            printf(
+                '<div class="notice notice-warning"><p>%s</p></div>',
+                esc_html__('The vehicles will soon be reworked and only vehicles without children will remain. Please use the recently introduced Units instead.', 'einsatzverwaltung')
+            );
+        }
+    }
+
+    public function addBadgeToMenu()
+    {
+        global $submenu;
+        $termsWithParentCount = $this->getTermsWithParentCount();
+        if ($termsWithParentCount > 0) {
+            $submenuKey = 'edit.php?post_type=' . Report::SLUG;
+            if (array_key_exists($submenuKey, $submenu)) {
+                $vehicleEntry = array_filter($submenu[$submenuKey], function ($entry) {
+                    return $entry[2] === 'edit-tags.php?taxonomy=fahrzeug&amp;post_type=einsatz';
+                });
+
+                foreach ($vehicleEntry as $id => $entry) {
+                    $entry[0] .= sprintf(
+                        ' <span class="awaiting-mod"><span class="pending-count">%d</span></span>',
+                        esc_html($termsWithParentCount)
+                    );
+                    $submenu[$submenuKey][$id] = $entry;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return int Returns the number of terms in this taxonomy that have a parent term.
+     */
+    private function getTermsWithParentCount()
+    {
+        $terms = get_terms(array('taxonomy' => $this->getSlug(), 'hide_empty' => false));
+        $childTerms = array_filter($terms, function (WP_Term $term) {
+            return $term->parent !== 0;
+        });
+        return count($childTerms);
     }
 }

--- a/src/Util/Formatter.php
+++ b/src/Util/Formatter.php
@@ -280,6 +280,21 @@ class Formatter
 
     /**
      * @param IncidentReport $report
+     *
+     * @return string
+     */
+    public function getUnits(IncidentReport $report)
+    {
+        $units = $report->getUnits();
+        $unitNames = array_map(function (WP_Post $unit) {
+            return sanitize_post_field('post_title', $unit->post_title, $unit->ID);
+        }, $units);
+
+        return join(', ', $unitNames);
+    }
+
+    /**
+     * @param IncidentReport $report
      * @param bool $makeLinks Fahrzeugname als Link zur Fahrzeugseite angeben, wenn diese eingetragen wurde
      * @param bool $showArchiveLinks Generiere zusätzlichen Link zur Archivseite des Fahrzeugs
      *

--- a/src/Util/Formatter.php
+++ b/src/Util/Formatter.php
@@ -20,7 +20,7 @@ class Formatter
     /**
      * @var array Ersetzbare Tags und ihre Beschreibungen
      */
-    private static $availableTags = array(
+    private $availableTags = array(
         '%title%' => 'Titel des Einsatzberichts',
         '%date%' => 'Datum der Alarmierung',
         '%time%' => 'Zeitpunkt der Alarmierung',
@@ -83,7 +83,7 @@ class Formatter
     public function formatIncidentData($pattern, $allowedTags = array(), $post = null, $context = 'post')
     {
         if (empty($allowedTags)) {
-            $allowedTags = array_keys(self::$availableTags);
+            $allowedTags = array_keys($this->availableTags);
         }
 
         // Content should be handled separately, so we will ignore it
@@ -457,12 +457,12 @@ class Formatter
      * @param string $tag
      * @return string
      */
-    public static function getLabelForTag($tag)
+    public function getLabelForTag($tag)
     {
-        if (!array_key_exists($tag, self::$availableTags)) {
+        if (!array_key_exists($tag, $this->availableTags)) {
             return '';
         }
 
-        return self::$availableTags[$tag];
+        return $this->availableTags[$tag];
     }
 }

--- a/src/Util/Formatter.php
+++ b/src/Util/Formatter.php
@@ -182,8 +182,7 @@ class Formatter
                 $replace = $incidentReport->getWorkforce();
                 break;
             case '%units%':
-                $unitNames = array_map('get_the_title', $incidentReport->getUnits());
-                $replace = join(', ', $unitNames);
+                $replace = $this->getUnits($incidentReport);
                 break;
             default:
                 return $pattern;

--- a/src/Util/Formatter.php
+++ b/src/Util/Formatter.php
@@ -41,6 +41,7 @@ class Formatter
         '%featuredImage%' => 'Beitragsbild',
         '%yearArchive%' => 'Link zum Jahresarchiv',
         '%workforce%' => 'Mannschaftsstärke',
+        '%units%' => 'Einheiten',
     );
 
     /**
@@ -179,6 +180,10 @@ class Formatter
                 break;
             case '%workforce%':
                 $replace = $incidentReport->getWorkforce();
+                break;
+            case '%units%':
+                $unitNames = array_map('get_the_title', $incidentReport->getUnits());
+                $replace = join(', ', $unitNames);
                 break;
             default:
                 return $pattern;

--- a/src/Widgets/AbstractWidget.php
+++ b/src/Widgets/AbstractWidget.php
@@ -1,0 +1,49 @@
+<?php
+namespace abrain\Einsatzverwaltung\Widgets;
+
+use WP_Post_Type;
+use WP_Widget;
+
+/**
+ * Class AbstractWidget
+ * @package abrain\Einsatzverwaltung\Widgets
+ */
+abstract class AbstractWidget extends WP_Widget
+{
+    /**
+     * @param WP_Post_Type $postTypeObject
+     * @param string $fieldName
+     * @param string $label
+     * @param int[] $selectedPostIds
+     * @param string $smallText
+     */
+    protected function echoChecklistBox(WP_Post_Type $postTypeObject, $fieldName, $label, $selectedPostIds, $smallText)
+    {
+        printf('<label>%s</label>', esc_html($label));
+        $posts = get_posts(array(
+            'post_type' => $postTypeObject->name,
+            'numberposts' => -1,
+            'order' => 'ASC',
+            'orderby' => 'name'
+        ));
+        if (empty($posts)) {
+            printf('<div class="checkboxlist">%s</div>', esc_html($postTypeObject->labels->not_found));
+        } else {
+            echo '<div class="checkboxlist"><ul>';
+            foreach ($posts as $post) {
+                $selected = in_array($post->ID, $selectedPostIds);
+                printf(
+                    '<li><label><input type="checkbox" name="%s[]" value="%d"%s>%s</label></li>',
+                    $this->get_field_name($fieldName),
+                    esc_attr($post->ID),
+                    checked($selected, true, false),
+                    esc_html($post->post_title)
+                );
+            }
+            printf(
+                '</ul><small>%s</small></div>',
+                esc_html($smallText)
+            );
+        }
+    }
+}

--- a/src/Widgets/RecentIncidents.php
+++ b/src/Widgets/RecentIncidents.php
@@ -93,6 +93,7 @@ class RecentIncidents extends WP_Widget
     private function echoReports($instance)
     {
         $reportQuery = new ReportQuery();
+        $reportQuery->setOrderAsc(false);
         $reportQuery->setLimit(absint($instance['anzahl']));
         $reports = $reportQuery->getReports();
 

--- a/src/Widgets/RecentIncidents.php
+++ b/src/Widgets/RecentIncidents.php
@@ -8,14 +8,13 @@ use abrain\Einsatzverwaltung\ReportQuery;
 use abrain\Einsatzverwaltung\Types\Unit;
 use abrain\Einsatzverwaltung\Util\Formatter;
 use abrain\Einsatzverwaltung\Utilities;
-use WP_Widget;
 
 /**
  * WordPress-Widget für die letzten X Einsätze
  *
  * @author Andreas Brain
  */
-class RecentIncidents extends WP_Widget
+class RecentIncidents extends AbstractWidget
 {
     /**
      * @var Formatter
@@ -47,12 +46,7 @@ class RecentIncidents extends WP_Widget
     }
 
     /**
-     * Front-end display of widget.
-     *
-     * @see WP_Widget::widget()
-     *
-     * @param array $args     Widget arguments.
-     * @param array $instance Saved values from database.
+     * @inheritDoc
      */
     public function widget($args, $instance)
     {
@@ -163,14 +157,7 @@ class RecentIncidents extends WP_Widget
     }
 
     /**
-     * Sanitize widget form values as they are saved.
-     *
-     * @see WP_Widget::update()
-     *
-     * @param array $newInstance Values just sent to be saved.
-     * @param array $oldInstance Previously saved values from database.
-     *
-     * @return array Updated safe values to be saved.
+     * @inheritDoc
      */
     public function update($newInstance, $oldInstance)
     {
@@ -197,12 +184,7 @@ class RecentIncidents extends WP_Widget
     }
 
     /**
-     * Back-end widget form.
-     *
-     * @see WP_Widget::form()
-     *
-     * @param array $instance Previously saved values from database.
-     * @return string
+     * @inheritDoc
      */
     public function form($instance)
     {
@@ -233,33 +215,13 @@ class RecentIncidents extends WP_Widget
             esc_attr($anzahl)
         );
 
-        printf('<label>%s</label>', esc_html__('Only show reports for these units:', 'einsatzverwaltung'));
-        $units = get_posts(array(
-            'post_type' => Unit::POST_TYPE,
-            'numberposts' => -1,
-            'order' => 'ASC',
-            'orderby' => 'name'
-        ));
-        if (empty($units)) {
-            $postTypeObject = get_post_type_object(Unit::POST_TYPE);
-            printf('<div class="checkboxlist">%s</div>', esc_html($postTypeObject->labels->not_found));
-        } else {
-            echo '<div class="checkboxlist"><ul>';
-            foreach ($units as $unit) {
-                $selected = in_array($unit->ID, $selectedUnits);
-                printf(
-                    '<li><label><input type="checkbox" name="%s[]" value="%d"%s>%s</label></li>',
-                    $this->get_field_name('units'),
-                    esc_attr($unit->ID),
-                    checked($selected, true, false),
-                    esc_html($unit->post_title)
-                );
-            }
-            printf(
-                '</ul><small>%s</small></div>',
-                esc_html__('Select no unit to show all reports', 'einsatzverwaltung')
-            );
-        }
+        $this->echoChecklistBox(
+            get_post_type_object(Unit::POST_TYPE),
+            'units',
+            __('Only show reports for these units:', 'einsatzverwaltung'),
+            $selectedUnits,
+            __('Select no unit to show all reports', 'einsatzverwaltung')
+        );
 
         printf(
             '<p><input id="%1$s" name="%2$s" type="checkbox" %3$s />&nbsp;<label for="%1$s">%4$s</label></p>',

--- a/src/Widgets/RecentIncidentsFormatted.php
+++ b/src/Widgets/RecentIncidentsFormatted.php
@@ -120,7 +120,8 @@ class RecentIncidentsFormatted extends WP_Widget
     );
     private $allowedTagsPattern = array('%title%', '%date%', '%time%', '%location%', '%duration%',
         '%incidentCommander%', '%incidentType%', '%incidentTypeColor%', '%url%', '%number%', '%seqNum%',
-        '%annotations%', '%vehicles%', '%additionalForces%', '%typesOfAlerting%', '%featuredImage%', '%workforce%');
+        '%annotations%', '%vehicles%', '%units%', '%additionalForces%', '%typesOfAlerting%', '%featuredImage%',
+        '%workforce%');
     private $allowedTagsAfter = array('%feedUrl%');
 
     /**

--- a/src/Widgets/RecentIncidentsFormatted.php
+++ b/src/Widgets/RecentIncidentsFormatted.php
@@ -274,7 +274,7 @@ class RecentIncidentsFormatted extends WP_Widget
         echo '<br><small>';
         _e('The following tags will be replaced:', 'einsatzverwaltung');
         foreach ($allowedTags as $tag) {
-            printf('<br><strong>%s</strong> (%s)', esc_html($tag), esc_html(Formatter::getLabelForTag($tag)));
+            printf('<br><strong>%s</strong> (%s)', esc_html($tag), esc_html($this->formatter->getLabelForTag($tag)));
         }
         echo '</small>';
     }

--- a/src/css/style-admin.css
+++ b/src/css/style-admin.css
@@ -102,3 +102,14 @@ li.dropzone {
 .settings_page_einsatzvw-settings label > code {
     margin-left: 0.5em;
 }
+
+.widgets-holder-wrap .checkboxlist, .customize-control-widget_form .checkboxlist {
+    border: 1px solid #ddd;
+    background-color: #fdfdfd;
+    padding: 8px;
+    margin: 4px 0 0 0;
+}
+
+.widgets-holder-wrap .checkboxlist ul {
+    margin-top: 0;
+}

--- a/tests/Widgets/RecentIncidentsFormattedTest.php
+++ b/tests/Widgets/RecentIncidentsFormattedTest.php
@@ -26,6 +26,7 @@ class RecentIncidentsFormattedTest extends WP_UnitTestCase
         $defaults = array(
             'title' => '',
             'numIncidents' => 3,
+            'units' => array(),
             'beforeContent' => '',
             'pattern' => '',
             'afterContent' => ''


### PR DESCRIPTION
Dieser PR ermöglicht es, Einsatzberichte einer oder mehreren Einheiten zuzuordnen. 

- Einsatzliste: Neue Spalte für Einheiten
- Einsatzliste: Filtern nach Einheiten
- Widgets: Filtern nach Einheiten
- Templates: Neuer Platzhalter `%units%`

Fixes #157 
Closes #118 