### PR TITLE
pec-events für Fahrzeugseiten ausschließen

### DIFF
--- a/src/Types/Vehicle.php
+++ b/src/Types/Vehicle.php
@@ -69,7 +69,7 @@ class Vehicle implements CustomTaxonomy
             'fahrzeugpid',
             'Fahrzeugseite',
             'Seite mit mehr Informationen &uuml;ber das Fahrzeug. Wird in Einsatzberichten mit diesem Fahrzeug verlinkt.',
-            array('einsatz', 'attachment', 'ai1ec_event', 'tribe_events')
+            array('einsatz', 'attachment', 'ai1ec_event', 'tribe_events', 'pec-events')
         ));
         $taxonomyCustomFields->addNumberInput($this->getSlug(), new NumberInput(
             'vehicleorder',


### PR DESCRIPTION
Im Drop-Down für die Auswahl einer Fahrzeugseite wird ein weiterer Beitragstyp (pec-events) ausgeschlossen, damit nicht alle Termine des Pro Event Calendar Plugins aufgelistet werden. Bei vielen Terminen kann dies zu einem Speicherfehler führen (https://github.com/abrain/einsatzverwaltung/issues/183).