### PR TITLE
Added API parameter 'workforce' from Thommes17

### DIFF
--- a/src/Api/Reports.php
+++ b/src/Api/Reports.php
@@ -100,6 +100,12 @@ class Reports extends WP_REST_Controller
                         'sanitize_callback' => 'sanitize_text_field',
                         'required' => false,
                     ),
+                    'einsatz_mannschaft' => array(
+                        'description' => __('The einsatz_mannschaft to be displayed in the report. Only integer values are allowed.', 'einsatzverwaltung'),
+                        'type' => 'integer',
+                        'validate_callback' => array($this, 'validateIsInt'),
+                        'required' => false,
+                    ),
                 ),
             ),
         ));
@@ -142,6 +148,11 @@ class Reports extends WP_REST_Controller
             $importObject->setResources(array_map('trim', $resources));
         }
 
+        // Process optional parameter einsatz_mannschaft
+        if (array_key_exists('einsatz_mannschaft', $params) && !empty($params['einsatz_mannschaft'])) {
+            $importObject->seteinsatz_mannschaft($params['einsatz_mannschaft']);
+        }
+        
         // Add post to database
         $publishReport = array_key_exists('publish', $params) && $params['publish'] === true;
         $reportInserter = new ReportInserter($publishReport);
@@ -200,6 +211,23 @@ class Reports extends WP_REST_Controller
     public function validateIsString($value, WP_REST_Request $request, string $key): bool
     {
         return is_string($value);
+    }
+
+    /**
+     * Validates if the passed parameter value is a int
+     *
+     * @param mixed $value
+     * @param WP_REST_Request $request
+     * @param string $key
+     *
+     * @return bool
+     *
+     * @noinspection PhpUnusedParameterInspection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function validateIsInt($value, WP_REST_Request $request, string $key): bool
+    {
+        return is_int($value);
     }
 
     /**

--- a/src/DataAccess/ReportInserter.php
+++ b/src/DataAccess/ReportInserter.php
@@ -106,6 +106,11 @@ class ReportInserter
             }
         }
 
+        $einsatz_mannschaft = $reportImportObject->geteinsatz_mannschaft();
+        if (!empty($einsatz_mannschaft)) {
+            $args['meta_input']['einsatz_mannschaft'] = $einsatz_mannschaft;
+        }
+        
         return $args;
     }
 

--- a/src/Model/ReportInsertObject.php
+++ b/src/Model/ReportInsertObject.php
@@ -34,6 +34,11 @@ class ReportInsertObject
     private $resources;
 
     /**
+     * @var int
+     */
+    private $einsatz_mannschaft;
+    
+    /**
      * @var DateTimeImmutable
      */
     private $startDateTime;
@@ -101,6 +106,14 @@ class ReportInsertObject
     }
 
     /**
+     * @return int
+     */
+    public function geteinsatz_mannschaft(): int
+    {
+        return $this->einsatz_mannschaft;
+    }
+    
+    /**
      * @return DateTimeImmutable
      */
     public function getStartDateTime(): DateTimeImmutable
@@ -154,5 +167,13 @@ class ReportInsertObject
     public function setResources(array $resources): void
     {
         $this->resources = $resources;
+    }
+
+    /**
+     * @param string[] $einsatz_mannschaft
+     */
+    public function seteinsatz_mannschaft(int $einsatz_mannschaft): void
+    {
+        $this->einsatz_mannschaft = $einsatz_mannschaft;
     }
 }


### PR DESCRIPTION
Allows to set the parameter 'workforce' via the Wordpress REST-API. The value type must be integer.

I reworked the changes made by @Thommes17.

This works fine for me.