### PR TITLE
Modernize Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,26 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:best-practices",
+    "group:linters",
+    "group:test",
+    ":maintainLockFilesWeekly",
     ":semanticCommits",
-    ":semanticPrefixFixDepsChoreOthers",
+    ":pinVersions",
     ":prHourlyLimit2",
     ":prConcurrentLimit10",
-    "group:allNonMajor",
-    "docker:disable",
-    ":pinVersions"
+    ":separateMultipleMajorReleases"
   ],
-  "major": {
-    "dependencyDashboardApproval": true
-  },
   "packageRules": [
-      {
-      "depTypeList": [ "require-dev" ],
-      "updateTypes": [ "patch", "minor", "digest"],
-      "groupName": "devDependencies (non-major)"
-    },
     {
-      "matchPackageNames": ["php"],
+      "matchDepNames": ["php"],
       "depTypeList": [ "require" ],
       "rangeStrategy": "widen"
     }


### PR DESCRIPTION
- apply best practices
- group test and linter packages
- remove approval for major versions, but open PRs for each major version separately
- maintain the lockfile on a weekly basis