### PR TITLE
Try different approach to test minimal versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -145,9 +145,11 @@ jobs:
           php-version: '7.1'
           coverage: none
           extensions: mysqli
-          tools: phpunit:6, yoast/phpunit-polyfills:1.1.1, brain/monkey:2.6.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install minimal test requirements
+        run: |
+          rm composer.json composer.lock
+          composer require --dev --no-progress "phpunit/phpunit:^6" "yoast/phpunit-polyfills:1.1.1" "brain/monkey:2.6.1"
 
       - name: Set up integration test
         run: ./bin/install-wp-tests.sh wptest_minimum wptestuser wptestpass 127.0.0.1:${{ job.services.mysql.ports['3306'] }} 5.6 true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,14 +142,12 @@ jobs:
         id: setup-minimum-php
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # 2.31.1
         with:
-          php-version: '7.4'
+          php-version: '7.1'
           coverage: none
           extensions: mysqli
-
-      - name: Downgrade PHPUnit
-        run: |
-          rm composer.lock
-          composer require --dev --update-with-all-dependencies --no-progress "phpunit/phpunit:^7.5" "mockery/mockery:1.3.6" "sebastian/comparator:^3.0"
+          tools: phpunit:6, yoast/phpunit-polyfills:1.1.1, brain/monkey:2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up integration test
         run: ./bin/install-wp-tests.sh wptest_minimum wptestuser wptestpass 127.0.0.1:${{ job.services.mysql.ports['3306'] }} 5.6 true


### PR DESCRIPTION
Instead of manipulating the existing composer file, leverage the `setup-php` action to install the required test tools. This should prevent the test from breaking whenever the dependencies are updated in the composer.json.