### PR TITLE
chore(deps): Remove redundant dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
     "friendsofphp/php-cs-fixer": "2.19.3",
     "php-cs-fixer/phpunit-constraint-isidenticalstring": "1.5.0",
     "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "1.5.0",
-    "sebastian/comparator": "4.0.8",
     "phpcompatibility/php-compatibility": "9.3.5",
     "yoast/phpunit-polyfills": "1.1.1",
     "phpcompatibility/phpcompatibility-wp": "2.1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64e59cbb33b9c0cc35d9fe899495f153",
+    "content-hash": "d18f37fb88b964f9e41df8583ccfeb8d",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
`sebastian/comparator` is already required by `phpunit`, so this is redundant and can possibly block Renovate runs.