### PR TITLE
fix(import): Show details for import error

### DIFF
--- a/src/Exceptions/ImportException.php
+++ b/src/Exceptions/ImportException.php
@@ -2,6 +2,7 @@
 namespace abrain\Einsatzverwaltung\Exceptions;
 
 use Exception;
+use Throwable;
 
 /**
  * Class ImportException
@@ -9,5 +10,28 @@ use Exception;
  */
 class ImportException extends Exception
 {
+    /**
+     * @var string[]
+     */
+    private $details;
 
+    /**
+     * @param string $message
+     * @param string[] $details
+     * @param $code
+     * @param Throwable|null $previous
+     */
+    public function __construct(string $message = "", array $details = [], $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->details = $details;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
+    }
 }

--- a/src/Import/Helper.php
+++ b/src/Import/Helper.php
@@ -441,7 +441,11 @@ class Helper
             // Neuen Beitrag anlegen
             $postId = wp_insert_post($insertArgs, true);
             if (is_wp_error($postId)) {
-                throw new ImportException('Konnte Einsatz nicht importieren: ' . $postId->get_error_message());
+                $errorMessage = sprintf('Konnte Einsatz nicht importieren: %s', $postId->get_error_message());
+                $details = array_filter($postId->get_all_error_data(), function ($value) {
+                    return is_string($value);
+                });
+                throw new ImportException($errorMessage, $details);
             }
 
             $importStatus->importSuccesss($postId);

--- a/src/Import/Tool.php
+++ b/src/Import/Tool.php
@@ -331,7 +331,12 @@ class Tool
         try {
             $this->helper->import($this->currentSource, $mapping, $importStatus);
         } catch (ImportException $e) {
-            $importStatus->abort('Import abgebrochen, Ursache: ' . $e->getMessage());
+            $importStatus->abort(sprintf('Import abgebrochen, Ursache: %1$s', $e->getMessage()));
+            $errorDetails = $e->getDetails();
+            if (count($errorDetails) > 0) {
+                $this->utilities->printError('WordPress gab folgende Details zur Fehlerursache zurück: ' . join(' ', $errorDetails));
+            }
+            $this->utilities->printInfo(sprintf('Erfolgreich importiert: %1$d von %2$d', $importStatus->currentStep, $importStatus->totalSteps));
             return;
         } catch (ImportPreparationException $e) {
             $importStatus->abort('Importvorbereitung abgebrochen, Ursache: ' . $e->getMessage());

--- a/tests/unit/Exceptions/ImportExceptionTest.php
+++ b/tests/unit/Exceptions/ImportExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace abrain\Einsatzverwaltung\Exceptions;
+
+use abrain\Einsatzverwaltung\UnitTestCase;
+use Exception;
+
+/**
+ * @covers \abrain\Einsatzverwaltung\Exceptions\ImportException
+ */
+class ImportExceptionTest extends UnitTestCase
+{
+    public function testDefaultsToEmptyValues()
+    {
+        $importException = new ImportException();
+        $this->assertEquals('', $importException->getMessage());
+        $this->assertEquals([], $importException->getDetails());
+        $this->assertEquals(0, $importException->getCode());
+        $this->assertEquals(null, $importException->getPrevious());
+    }
+
+    public function testAcceptsCustomValues()
+    {
+        $previous = new Exception('the previous error');
+        $details = ['this happened', 'and this also went wrong'];
+        $importException = new ImportException('lorem ipsum', $details, 8493, $previous);
+        $this->assertEquals('lorem ipsum', $importException->getMessage());
+        $this->assertEquals($details, $importException->getDetails());
+        $this->assertEquals(8493, $importException->getCode());
+        $this->assertEquals($previous, $importException->getPrevious());
+    }
+}


### PR DESCRIPTION
If `wp_insert_post` returns additional details in the `WP_Error` object, show them to the user. Also let the user know how many imports were successful before the error.