### PR TITLE
Use generic admin page for import and export

### DIFF
--- a/src/Admin/Initializer.php
+++ b/src/Admin/Initializer.php
@@ -5,7 +5,7 @@ namespace abrain\Einsatzverwaltung\Admin;
 use abrain\Einsatzverwaltung\Core;
 use abrain\Einsatzverwaltung\Data;
 use abrain\Einsatzverwaltung\Export\Tool as ExportTool;
-use abrain\Einsatzverwaltung\Import\Tool as ImportTool;
+use abrain\Einsatzverwaltung\Import\Page as ImportPage;
 use abrain\Einsatzverwaltung\Options;
 use abrain\Einsatzverwaltung\PermalinkController;
 use abrain\Einsatzverwaltung\Settings\MainPage;
@@ -57,8 +57,8 @@ class Initializer
         add_action('admin_menu', array($mainPage, 'addToSettingsMenu'));
         add_action('admin_init', array($mainPage, 'registerSettings'));
 
-        $importTool = new ImportTool($utilities, $data);
-        add_action('admin_menu', array($importTool, 'addToolToMenu'));
+        $importPage = new ImportPage($utilities, $data);
+        add_action('admin_menu', array($importPage, 'registerAsToolPage'));
 
         $exportTool = new ExportTool();
         add_action('admin_menu', array($exportTool, 'addToolToMenu'));

--- a/src/Admin/Initializer.php
+++ b/src/Admin/Initializer.php
@@ -4,7 +4,7 @@ namespace abrain\Einsatzverwaltung\Admin;
 
 use abrain\Einsatzverwaltung\Core;
 use abrain\Einsatzverwaltung\Data;
-use abrain\Einsatzverwaltung\Export\Tool as ExportTool;
+use abrain\Einsatzverwaltung\Export\Page as ExportPage;
 use abrain\Einsatzverwaltung\Import\Page as ImportPage;
 use abrain\Einsatzverwaltung\Options;
 use abrain\Einsatzverwaltung\PermalinkController;
@@ -60,10 +60,10 @@ class Initializer
         $importPage = new ImportPage($utilities, $data);
         add_action('admin_menu', array($importPage, 'registerAsToolPage'));
 
-        $exportTool = new ExportTool();
-        add_action('admin_menu', array($exportTool, 'addToolToMenu'));
-        add_action('init', array($exportTool, 'startExport'), 20); // 20, damit alles andere initialisiert ist
-        add_action('admin_enqueue_scripts', array($exportTool, 'enqueueAdminScripts'));
+        $exportPage = new ExportPage();
+        add_action('admin_menu', array($exportPage, 'registerAsToolPage'));
+        add_action('init', array($exportPage, 'startExport'), 20); // 20, damit alles andere initialisiert ist
+        add_action('admin_enqueue_scripts', array($exportPage, 'enqueueAdminScripts'));
 
         $tasksPage = new TasksPage($utilities, $data);
         add_action('admin_menu', array($tasksPage, 'registerPage'));

--- a/src/AdminPage.php
+++ b/src/AdminPage.php
@@ -24,13 +24,20 @@ abstract class AdminPage
     private $pageTitle;
 
     /**
+     * @var string
+     */
+    private $capability;
+
+    /**
      * @param string $pageTitle
      * @param string $menuSlug
+     * @param string $capability
      */
-    public function __construct(string $pageTitle, string $menuSlug)
+    public function __construct(string $pageTitle, string $menuSlug, string $capability = 'manage_options')
     {
         $this->pageTitle = $pageTitle;
         $this->menuSlug = $menuSlug;
+        $this->capability = $capability;
     }
 
     abstract protected function echoPageContent();
@@ -83,7 +90,7 @@ abstract class AdminPage
         add_management_page(
             $this->pageTitle,
             esc_html($this->pageTitle),
-            'manage_options',
+            $this->capability,
             $this->menuSlug,
             array($this, 'render')
         );

--- a/src/AdminPage.php
+++ b/src/AdminPage.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace abrain\Einsatzverwaltung;
+
+use function add_management_page;
+use function esc_html;
+use function printf;
+
+/**
+ * Base class for pages in the admin area.
+ *
+ * @package abrain\Einsatzverwaltung
+ */
+abstract class AdminPage
+{
+    /**
+     * @var string
+     */
+    private $menuSlug;
+
+    /**
+     * @var string
+     */
+    private $pageTitle;
+
+    /**
+     * @param string $pageTitle
+     * @param string $menuSlug
+     */
+    public function __construct(string $pageTitle, string $menuSlug)
+    {
+        $this->pageTitle = $pageTitle;
+        $this->menuSlug = $menuSlug;
+    }
+
+    abstract protected function echoPageContent();
+
+    /**
+     * Prints an error message.
+     *
+     * @param string $message The message text.
+     */
+    protected function printError(string $message)
+    {
+        printf('<p class="notice notice-error">%s</p>', esc_html($message));
+    }
+
+    /**
+     * Prints an informational message.
+     *
+     * @param string $message The message text.
+     */
+    protected function printInfo(string $message)
+    {
+        printf('<p class="notice notice-info">%s</p>', esc_html($message));
+    }
+
+    /**
+     * Prints a success message.
+     *
+     * @param string $message The message text.
+     */
+    protected function printSuccess(string $message)
+    {
+        printf('<p class="notice notice-success">%s</p>', esc_html($message));
+    }
+
+    /**
+     * Prints a warning message.
+     *
+     * @param string $message The message text.
+     */
+    protected function printWarning(string $message)
+    {
+        printf('<p class="notice notice-warning">%s</p>', esc_html($message));
+    }
+
+    /**
+     * Registers this page under the Tools menu.
+     */
+    public function registerAsToolPage()
+    {
+        add_management_page(
+            $this->pageTitle,
+            esc_html($this->pageTitle),
+            'manage_options',
+            $this->menuSlug,
+            array($this, 'render')
+        );
+    }
+
+    /**
+     * Generates the output of the page.
+     */
+    public function render()
+    {
+        echo '<div class="wrap">';
+        printf("<h1>%s</h1>", esc_html($this->pageTitle));
+        $this->echoPageContent();
+        echo '</div>';
+    }
+}

--- a/src/Export/Page.php
+++ b/src/Export/Page.php
@@ -1,6 +1,7 @@
 <?php
 namespace abrain\Einsatzverwaltung\Export;
 
+use abrain\Einsatzverwaltung\AdminPage;
 use abrain\Einsatzverwaltung\Core;
 use abrain\Einsatzverwaltung\Export\Formats\Csv;
 use abrain\Einsatzverwaltung\Export\Formats\Excel;
@@ -9,7 +10,7 @@ use abrain\Einsatzverwaltung\Export\Formats\Json;
 /**
  * Werkzeug für den Export von Einsatzberichten in verschiedenen Formaten
  */
-class Tool
+class Page extends AdminPage
 {
     const EVW_TOOL_EXPORT_SLUG = 'einsatzvw-tool-export';
 
@@ -23,21 +24,8 @@ class Tool
      */
     public function __construct()
     {
+        parent::__construct('Einsatzberichte exportieren', self::EVW_TOOL_EXPORT_SLUG, 'export');
         $this->loadFormats();
-    }
-
-    /**
-     * Fügt das Werkzeug zum Menü hinzu
-     */
-    public function addToolToMenu()
-    {
-        add_management_page(
-            'Einsatzberichte exportieren',
-            'Einsatzberichte exportieren',
-            'export',
-            self::EVW_TOOL_EXPORT_SLUG,
-            array($this, 'renderToolPage')
-        );
     }
 
     /**
@@ -92,10 +80,8 @@ class Tool
     /**
      * Generiert den Inhalt der Werkzeugseite
      */
-    public function renderToolPage()
+    protected function echoPageContent()
     {
-        echo '<div class="wrap">';
-        echo '<h1>Einsatzberichte exportieren</h1>';
         echo '<p>Dieses Werkzeug exportiert Einsatzberichte in verschiedenen Formaten.</p>'; ?>
 <form method="get" id="export-form">
     <input type="hidden" name="page" value="einsatzvw-tool-export">
@@ -145,7 +131,6 @@ class Tool
 </form>
 
         <?php
-        echo '</div>';
     }
 
     private function renderDateOptions()

--- a/tests/unit/AdminPageTest.php
+++ b/tests/unit/AdminPageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace abrain\Einsatzverwaltung;
+
+use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * @covers \abrain\Einsatzverwaltung\AdminPage
+ */
+class AdminPageTest extends UnitTestCase
+{
+    /**
+     * @throws ExpectationArgsRequired
+     */
+    public function testRegistersPage()
+    {
+        $page = $this->getMockForAbstractClass(AdminPage::class, ['Title of the page', 'menu-slug']);
+        expect('add_management_page')->once()->with('Title of the page', 'Title of the page', 'manage_options', 'menu-slug', array($page, 'render'));
+        $page->registerAsToolPage();
+    }
+
+    public function testRenderPage()
+    {
+        $page = $this->getMockForAbstractClass(AdminPage::class, ['Page Title', 'test-page']);
+        $page->expects($this->any())
+            ->method('echoPageContent')
+            ->will($this->returnCallback(function () {
+                echo '<p>Some content</p>';
+            }));
+        $this->expectOutputString('<div class="wrap"><h1>Page Title</h1><p>Some content</p></div>');
+        $page->render();
+    }
+}

--- a/tests/unit/AdminPageTest.php
+++ b/tests/unit/AdminPageTest.php
@@ -20,6 +20,16 @@ class AdminPageTest extends UnitTestCase
         $page->registerAsToolPage();
     }
 
+    /**
+     * @throws ExpectationArgsRequired
+     */
+    public function testRegistersPageWithCustomCapability()
+    {
+        $page = $this->getMockForAbstractClass(AdminPage::class, ['Title of the page', 'menu-slug', 'needed-capability']);
+        expect('add_management_page')->once()->with('Title of the page', 'Title of the page', 'needed-capability', 'menu-slug', array($page, 'render'));
+        $page->registerAsToolPage();
+    }
+
     public function testRenderPage()
     {
         $page = $this->getMockForAbstractClass(AdminPage::class, ['Page Title', 'test-page']);


### PR DESCRIPTION
Introduce a more generic `AdminPage`, that pages in the admin are can inherit from. That way, those pages can behave the same and make common tasks (e.g. printing messages) reusable. This PR also moves the import and export pages to that new parent class.