### PR TITLE
Pin CI workflow to Ubuntu 22.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   compliance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -47,7 +47,7 @@ jobs:
         run: cs2pr ./phpcs-report.xml
 
   test-latest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - compliance
 
@@ -124,7 +124,7 @@ jobs:
 
 
   test-minimum:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - compliance
 


### PR DESCRIPTION
The ubuntu-latest image switched to 24.04 and is missing SVN.