### PR TITLE
feat: Allow setting featured image for Einsatz posts via API

### DIFF
--- a/src/includes/Api/Reports.php
+++ b/src/includes/Api/Reports.php
@@ -20,6 +20,8 @@ use function is_wp_error;
 use function strlen;
 use function trim;
 use function wp_strip_all_tags;
+use function wp_get_attachment_url;
+use function wp_attachment_is_image;
 use const DATE_RFC3339;
 
 /**
@@ -100,6 +102,13 @@ class Reports extends WP_REST_Controller
                         'sanitize_callback' => 'sanitize_text_field',
                         'required' => false,
                     ),
+                    'image_id' => array(
+                        'description' => __('The ID of an image in the WordPress Media Library to be set as the featured image.', 'einsatzverwaltung'),
+                        'type' => 'integer',
+                        'validate_callback' => array($this, 'validateAttachmentId'),
+                        'sanitize_callback' => 'absint',
+                        'required' => false,
+                    ),
                 ),
             ),
         ));
@@ -140,6 +149,11 @@ class Reports extends WP_REST_Controller
         if (array_key_exists('resources', $params) && !empty($params['resources'])) {
             $resources = explode(',', $params['resources']);
             $importObject->setResources(array_map('trim', $resources));
+        }
+
+        // Process optional parameter image_id
+        if (array_key_exists('image_id', $params) && !empty($params['image_id'])) {
+            $importObject->setImageId((int)$params['image_id']);
         }
 
         // Add post to database
@@ -217,5 +231,29 @@ class Reports extends WP_REST_Controller
     public function validateStringNotEmpty($value, WP_REST_Request $request, string $key): bool
     {
         return is_string($value) && strlen(trim($value)) > 0;
+    }
+
+    /**
+     * Validates if the passed parameter value is an existing attachment ID and if this attachment is an image.
+     *
+     * @param mixed $value
+     * @param WP_REST_Request $request
+     * @param string $key
+     *
+     * @return bool
+     *
+     * @noinspection PhpUnusedParameterInspection
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function validateAttachmentId($value, WP_REST_Request $request, string $key): bool
+    {
+        if (!is_numeric($value)) {
+            return false;
+        }
+        $id = (int)$value;
+        if ($id <= 0) {
+            return false;
+        }
+        return wp_get_attachment_url($id) !== false && wp_attachment_is_image($id);
     }
 }

--- a/src/includes/DataAccess/ReportInserter.php
+++ b/src/includes/DataAccess/ReportInserter.php
@@ -21,6 +21,7 @@ use function get_terms;
 use function is_wp_error;
 use function wp_insert_post;
 use function wp_insert_term;
+use function set_post_thumbnail;
 
 /**
  * Inserts incident reports into the database
@@ -202,6 +203,17 @@ class ReportInserter
             return $insertArgs;
         }
 
-        return wp_insert_post($insertArgs, true);
+        $postId = wp_insert_post($insertArgs, true);
+
+        if (is_wp_error($postId)) {
+            return $postId;
+        }
+
+        $imageId = $importObject->getImageId();
+        if ($imageId !== null && $imageId > 0) {
+            set_post_thumbnail($postId, $imageId);
+        }
+
+        return $postId;
     }
 }

--- a/src/includes/Model/ReportInsertObject.php
+++ b/src/includes/Model/ReportInsertObject.php
@@ -44,6 +44,11 @@ class ReportInsertObject
     private $title;
 
     /**
+     * @var int|null
+     */
+    private $imageId = null;
+
+    /**
      * @param DateTimeImmutable $startDate
      * @param string $title
      */
@@ -154,5 +159,21 @@ class ReportInsertObject
     public function setResources(array $resources): void
     {
         $this->resources = $resources;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getImageId(): ?int
+    {
+        return $this->imageId;
+    }
+
+    /**
+     * @param int|null $imageId
+     */
+    public function setImageId(?int $imageId): void
+    {
+        $this->imageId = $imageId;
     }
 }

--- a/tests/unit/Api/ReportsTest.php
+++ b/tests/unit/Api/ReportsTest.php
@@ -6,6 +6,7 @@ use abrain\Einsatzverwaltung\UnitTestCase;
 use Brain\Monkey\Expectation\Exception\ExpectationArgsRequired;
 use DateTimeImmutable;
 use Mockery;
+use WP_REST_Request; // Added for type hinting
 use function array_key_exists;
 use function Brain\Monkey\Functions\expect;
 
@@ -21,6 +22,13 @@ class ReportsTest extends UnitTestCase
         parent::setUp();
         Mockery::mock('WP_REST_Controller');
         Mockery::namedMock('WP_REST_Server', 'abrain\Einsatzverwaltung\Stubs\WPRESTServerStub');
+        // Mock WordPress functions that might be called directly or as callbacks
+        expect('__')->atLeast()->zeroTimes()->andReturnUsing(function ($text, $domain) {
+            return $text; // Simple passthrough for descriptions
+        });
+        expect('absint')->atLeast()->zeroTimes()->andReturnUsing(function ($value) {
+            return abs((int)$value);
+        });
     }
 
     /**
@@ -54,6 +62,24 @@ class ReportsTest extends UnitTestCase
                 }
             }
         }
+
+        // Specifically check image_id argument in the CREATABLE route
+        $creatableRouteArgs = null;
+        foreach ($routeArgs as $routeOptions) {
+            if (isset($routeOptions['methods']) && $routeOptions['methods'] === \WP_REST_Server::CREATABLE) {
+                $creatableRouteArgs = $routeOptions['args'];
+                break;
+            }
+        }
+        $this->assertNotNull($creatableRouteArgs, "CREATABLE route options not found.");
+        $this->assertArrayHasKey('image_id', $creatableRouteArgs, "image_id argument not found in CREATABLE route.");
+
+        $imageIdArgs = $creatableRouteArgs['image_id'];
+        $this->assertEquals(__('The ID of an image in the WordPress Media Library to be set as the featured image.', 'einsatzverwaltung'), $imageIdArgs['description']);
+        $this->assertEquals('integer', $imageIdArgs['type']);
+        $this->assertEquals([new Reports(), 'validateAttachmentId'], $imageIdArgs['validate_callback']);
+        $this->assertEquals('absint', $imageIdArgs['sanitize_callback']);
+        $this->assertFalse($imageIdArgs['required']);
     }
 
     /**
@@ -124,6 +150,47 @@ class ReportsTest extends UnitTestCase
     }
 
     /**
+     * @dataProvider provideValidateAttachmentIdCases
+     */
+    public function testValidateAttachmentId($value, $urlReturnValue, $isImageReturnValue, $expectedResult)
+    {
+        $request = Mockery::mock(WP_REST_Request::class); // Mock WP_REST_Request
+        $reports = new Reports();
+
+        // Reset mocks for WordPress functions for each data set
+        Mockery::getContainer()->mockery_close(); // Close any existing Mockery instances from previous tests/data providers
+        parent::setUp(); // Re-run setup to re-initialize mocks if needed, or manage mocks more granularly
+
+        if (is_int($value) && $value > 0) { // Only mock for positive integer IDs
+            expect('wp_get_attachment_url')
+                ->once()
+                ->with($value)
+                ->andReturn($urlReturnValue);
+
+            if ($urlReturnValue !== false) {
+                expect('wp_attachment_is_image')
+                    ->once()
+                    ->with($value)
+                    ->andReturn($isImageReturnValue);
+            }
+        }
+
+        $this->assertEquals($expectedResult, $reports->validateAttachmentId($value, $request, 'image_id'));
+    }
+
+    public function provideValidateAttachmentIdCases(): array
+    {
+        return [
+            'valid image ID' => [123, 'http://example.com/image.jpg', true, true],
+            'non-image attachment ID' => [124, 'http://example.com/document.pdf', false, false],
+            'non-existent attachment ID' => [125, false, null, false], // wp_attachment_is_image not called
+            'non-integer value' => ['abc', null, null, false], // WordPress functions not called
+            'zero ID' => [0, null, null, false], // WordPress functions not called
+            'negative ID' => [-1, null, null, false], // WordPress functions not called
+        ];
+    }
+
+    /**
      * @throws ExpectationArgsRequired
      */
     public function testCreateItemMinimalData()
@@ -139,6 +206,7 @@ class ReportsTest extends UnitTestCase
         $importObject->expects('__construct')->once()->with(Mockery::on(function ($arg) {
             return $arg instanceof DateTimeImmutable && $arg->getTimestamp() === 1630266479;
         }), 'A reason');
+        $importObject->expects('setImageId')->never(); // Ensure it's not called
 
         $reportInserter = Mockery::mock('overload:abrain\Einsatzverwaltung\DataAccess\ReportInserter');
         $reportInserter->expects('__construct')->once()->with(false);
@@ -159,9 +227,9 @@ class ReportsTest extends UnitTestCase
     /**
      * @throws ExpectationArgsRequired
      */
-    public function testCreateItemComplete()
+    public function testCreateItemCompleteWithoutImageId()
     {
-        $request = Mockery::mock('WP_REST_Request');
+        $request = Mockery::mock(WP_REST_Request::class); // Mock WP_REST_Request
         $request->expects('get_params')->once()->andReturn([
             'reason' => 'A reason',
             'date_start' => '2021-08-29T21:47:59+0200',
@@ -185,6 +253,7 @@ class ReportsTest extends UnitTestCase
         $importObject->expects('setKeyword')->once()->with('key-word');
         $importObject->expects('setLocation')->once()->with('It happened here');
         $importObject->expects('setResources')->once()->with(['resource 1', 'another resource', 'and number three']);
+        $importObject->expects('setImageId')->never(); // Ensure it's not called
 
         $reportInserter = Mockery::mock('overload:abrain\Einsatzverwaltung\DataAccess\ReportInserter');
         $reportInserter->expects('__construct')->once()->with(true);
@@ -204,9 +273,64 @@ class ReportsTest extends UnitTestCase
     /**
      * @throws ExpectationArgsRequired
      */
+    public function testCreateItemWithValidImageId()
+    {
+        $validImageId = 123;
+        // sanitize_callback 'absint' is mocked in setUp to return abs((int)$value)
+        // So, if $validImageId is '123', absint will make it 123.
+        // If it were '-123', absint would make it 123.
+
+        $request = Mockery::mock(WP_REST_Request::class);
+        $request->expects('get_params')->once()->andReturn([
+            'reason' => 'A reason with image',
+            'date_start' => '2021-08-29T21:47:59+0200',
+            'image_id' => $validImageId, // Raw value before sanitization
+            'publish' => false,
+        ]);
+
+        // These mocks are for the check within create_item, not for the validate_callback.
+        // The validate_callback is tested separately by testValidateAttachmentId
+        // and its correct registration is tested in testRegisterRoutes.
+        // For this create_item test, we assume the image_id has passed validation
+        // and is now being processed.
+        // The `absint` sanitize_callback (mocked in setUp) will have run.
+        $sanitizedImageId = abs((int)$validImageId);
+
+
+        $importObject = Mockery::mock('overload:abrain\Einsatzverwaltung\Model\ReportInsertObject');
+        $importObject->expects('__construct')->once()->with(
+            Mockery::on(function ($arg) {
+                return $arg instanceof DateTimeImmutable && $arg->getTimestamp() === 1630266479;
+            }),
+            'A reason with image'
+        );
+        // Expect setImageId to be called with the *sanitized* image_id
+        $importObject->expects('setImageId')->once()->with($sanitizedImageId);
+
+
+        $reportInserter = Mockery::mock('overload:abrain\Einsatzverwaltung\DataAccess\ReportInserter');
+        $reportInserter->expects('__construct')->once()->with(false); // publish is false
+        $reportInserter->expects('insertReport')->once()->with(Mockery::on(function ($arg) use ($sanitizedImageId) {
+            // Check that the ReportInsertObject passed to ReportInserter has the correct imageId
+            return $arg instanceof ReportInsertObject && $arg->getImageId() === $sanitizedImageId;
+        }))->andReturn(789); // New post ID
+
+        $response = Mockery::mock('overload:WP_REST_Response');
+        $response->expects('__construct')->once()->with(['id' => 789]);
+        $response->expects('set_status')->once()->with(201);
+
+        $reportsApi = new Reports();
+        $restResponse = $reportsApi->create_item($request);
+        $this->assertInstanceOf('WP_REST_Response', $restResponse);
+    }
+
+
+    /**
+     * @throws ExpectationArgsRequired
+     */
     public function testCreateItemError()
     {
-        $request = Mockery::mock('WP_REST_Request');
+        $request = Mockery::mock(WP_REST_Request::class); // Mock WP_REST_Request
         $request->expects('get_params')->once()->andReturn([
             'reason' => 'A reason',
             'date_start' => '2021-08-29T21:47:59+0200'
@@ -214,11 +338,11 @@ class ReportsTest extends UnitTestCase
 
         $wpError = Mockery::mock('WP_Error');
 
-        // Create an overload mock, as the object gets created inside the tested function
         $importObject = Mockery::mock('overload:abrain\Einsatzverwaltung\Model\ReportInsertObject');
         $importObject->expects('__construct')->once()->with(Mockery::on(function ($arg) {
             return $arg instanceof DateTimeImmutable && $arg->getTimestamp() === 1630266479;
         }), 'A reason');
+        $importObject->expects('setImageId')->never(); // Ensure it's not called
 
         $reportInserter = Mockery::mock('overload:abrain\Einsatzverwaltung\DataAccess\ReportInserter');
         $reportInserter->expects('__construct')->once()->with(false);
@@ -226,11 +350,8 @@ class ReportsTest extends UnitTestCase
             return $arg instanceof ReportInsertObject;
         }))->andReturn($wpError);
 
-
-        // Create an overload mock, as the object gets created inside the tested function
-        $response = Mockery::mock('overload:WP_REST_Response');
-        $response->expects('__construct')->once()->with(['id' => 614]);
-        $response->expects('set_status')->once()->with(201);
+        // If insertReport returns WP_Error, a WP_REST_Response is not constructed by our code.
+        // So, no need to mock WP_REST_Response here for the error path.
 
         $reportsApi = new Reports();
         $this->assertEquals($wpError, $reportsApi->create_item($request));

--- a/tests/unit/DataAccess/ReportInserterTest.php
+++ b/tests/unit/DataAccess/ReportInserterTest.php
@@ -29,8 +29,10 @@ class ReportInserterTest extends UnitTestCase
         $importObject->expects('getResources')->once()->andReturn([]);
         $importObject->expects('getStartDateTime')->once()->andReturn(new DateTimeImmutable('2021-08-29T17:51:15+0200'));
         $importObject->expects('getTitle')->once()->andReturn('Some title');
+        $importObject->expects('getImageId')->once()->andReturnNull(); // SCENARIO 2 check
 
         expect('wp_insert_post')->once()->with(Mockery::capture($insertArgs), true)->andReturn(4122);
+        expect('set_post_thumbnail')->never(); // SCENARIO 2 check
 
         $reportInserter = new ReportInserter();
         $this->assertEquals(4122, $reportInserter->insertReport($importObject));
@@ -59,6 +61,7 @@ class ReportInserterTest extends UnitTestCase
         $importObject->expects('getLocation')->once()->andReturn('The location');
         $importObject->expects('getResources')->once()->andReturn(['resource', 'Resource 2', 'unknown', 'abc', 'def']);
         $importObject->expects('getEndDateTime')->once()->andReturn(new DateTimeImmutable('2021-08-29T21:34:42+0200'));
+        $importObject->expects('getImageId')->once()->andReturnNull(); // Assuming no image for this complete test
 
         // Incident Type exists already
         $term = Mockery::mock('\WP_Term');
@@ -84,6 +87,10 @@ class ReportInserterTest extends UnitTestCase
         expect('get_terms')->once()->with(Mockery::capture($byAliasArgs))->andReturn([$resource3, $resource4]);
 
         expect('wp_insert_post')->once()->with(Mockery::capture($insertArgs), true)->andReturn(91234);
+        // Assuming no image for this complete test, so set_post_thumbnail should not be called.
+        // If this test were to include an image, this expectation would change.
+        expect('set_post_thumbnail')->never();
+
 
         $reportInserter = new ReportInserter(true);
         $this->assertEquals(91234, $reportInserter->insertReport($importObject));
@@ -200,6 +207,7 @@ class ReportInserterTest extends UnitTestCase
         $importObject->expects('getResources')->once()->andReturn([]);
         $importObject->expects('getStartDateTime')->once()->andReturn(new DateTimeImmutable());
         $importObject->expects('getTitle')->once()->andReturn('');
+        $importObject->expects('getImageId')->once()->andReturnNull(); // Assuming no image
 
         // Incident Type is not found by name, search by alias
         expect('get_term_by')->once()->with('name', 'Alternative keyword', 'einsatzart')->andReturn(false);
@@ -210,6 +218,7 @@ class ReportInserterTest extends UnitTestCase
         expect('get_terms')->once()->with(Mockery::capture($getTermsArgs))->andReturn([$term1, $term2]);
 
         expect('wp_insert_post')->once()->with(Mockery::capture($insertArgs), true)->andReturn(9114);
+        expect('set_post_thumbnail')->never(); // Assuming no image
 
         $reportInserter = new ReportInserter();
         $this->assertEquals(9114, $reportInserter->insertReport($importObject));
@@ -224,5 +233,113 @@ class ReportInserterTest extends UnitTestCase
             ]
         ], $getTermsArgs);
         $this->assertEquals([8451], $insertArgs['tax_input']['einsatzart']);
+    }
+
+    /**
+     * SCENARIO 1: ReportInsertObject has a valid imageId
+     * @throws ExpectationArgsRequired
+     */
+    public function testInsertReportWithImageId()
+    {
+        $postId = 1;
+        $imageId = 123;
+
+        $importObject = Mockery::mock('abrain\Einsatzverwaltung\Model\ReportInsertObject');
+        // Mock only essential methods for this test, assume getInsertArgs works
+        $importObject->expects('getStartDateTime')->once()->andReturn(new DateTimeImmutable());
+        $importObject->expects('getTitle')->once()->andReturn('Test Title with Image');
+        $importObject->expects('getContent')->once()->andReturn('');
+        $importObject->expects('getEndDateTime')->once()->andReturnNull();
+        $importObject->expects('getKeyword')->once()->andReturn('');
+        $importObject->expects('getLocation')->once()->andReturn('');
+        $importObject->expects('getResources')->once()->andReturn([]);
+        $importObject->expects('getImageId')->once()->andReturn($imageId);
+
+        expect('wp_insert_post')
+            ->once()
+            ->with(Mockery::on(function ($args) {
+                // We don't need to validate all insertArgs here, just that it's an array
+                return is_array($args);
+            }), true)
+            ->andReturn($postId);
+
+        expect('set_post_thumbnail')
+            ->once()
+            ->with($postId, $imageId);
+
+        $reportInserter = new ReportInserter();
+        $this->assertEquals($postId, $reportInserter->insertReport($importObject));
+    }
+
+    /**
+     * SCENARIO 3: ReportInsertObject has 0 or a negative value as imageId
+     * @throws ExpectationArgsRequired
+     * @dataProvider provideInvalidImageIds
+     */
+    public function testInsertReportWithInvalidImageId($invalidImageId)
+    {
+        $postId = 2;
+
+        $importObject = Mockery::mock('abrain\Einsatzverwaltung\Model\ReportInsertObject');
+        $importObject->expects('getStartDateTime')->once()->andReturn(new DateTimeImmutable());
+        $importObject->expects('getTitle')->once()->andReturn('Test Title with Invalid ImageId');
+        $importObject->expects('getContent')->once()->andReturn('');
+        $importObject->expects('getEndDateTime')->once()->andReturnNull();
+        $importObject->expects('getKeyword')->once()->andReturn('');
+        $importObject->expects('getLocation')->once()->andReturn('');
+        $importObject->expects('getResources')->once()->andReturn([]);
+        $importObject->expects('getImageId')->once()->andReturn($invalidImageId);
+
+        expect('wp_insert_post')
+            ->once()
+            ->with(Mockery::type('array'), true)
+            ->andReturn($postId);
+
+        expect('set_post_thumbnail')->never();
+
+        $reportInserter = new ReportInserter();
+        $this->assertEquals($postId, $reportInserter->insertReport($importObject));
+    }
+
+    public function provideInvalidImageIds(): array
+    {
+        return [
+            'imageId is 0' => [0],
+            'imageId is negative' => [-10],
+        ];
+    }
+
+    /**
+     * SCENARIO 4: wp_insert_post returns a WP_Error
+     * @throws ExpectationArgsRequired
+     */
+    public function testInsertReportWhenInsertPostFails()
+    {
+        $imageId = 456; // A valid imageId, to ensure set_post_thumbnail is skipped due to WP_Error
+        $wpError = Mockery::mock('WP_Error');
+
+        $importObject = Mockery::mock('abrain\Einsatzverwaltung\Model\ReportInsertObject');
+        $importObject->expects('getStartDateTime')->once()->andReturn(new DateTimeImmutable());
+        $importObject->expects('getTitle')->once()->andReturn('Test Title WP_Error');
+        $importObject->expects('getContent')->once()->andReturn('');
+        $importObject->expects('getEndDateTime')->once()->andReturnNull();
+        $importObject->expects('getKeyword')->once()->andReturn('');
+        $importObject->expects('getLocation')->once()->andReturn('');
+        $importObject->expects('getResources')->once()->andReturn([]);
+        // getImageId() might not be called if getInsertArgs returns error first,
+        // but if getInsertArgs succeeds, then getImageId() will be called before the error check for $postId
+        // For simplicity, we assume getInsertArgs is fine and error happens at wp_insert_post
+        $importObject->expects('getImageId')->atMost()->once()->andReturn($imageId);
+
+
+        expect('wp_insert_post')
+            ->once()
+            ->with(Mockery::type('array'), true)
+            ->andReturn($wpError);
+
+        expect('set_post_thumbnail')->never();
+
+        $reportInserter = new ReportInserter();
+        $this->assertSame($wpError, $reportInserter->insertReport($importObject));
     }
 }


### PR DESCRIPTION
Adds an `image_id` parameter to the `einsatzverwaltung/v1/reports` API endpoint.

This allows clients to associate an image from the WordPress Media Library as the featured image for an "Einsatz" (report) post during its creation.

To use this, you should first upload an image to the WordPress Media Library and then pass the resulting attachment ID as the `image_id` in the POST request to the `/reports` endpoint.

The following changes were made:
- Modified `ReportInsertObject.php` to include an `imageId` property.
- Updated `Api/Reports.php` to accept an optional `image_id` integer parameter, validate it as a valid attachment ID, and pass it to the `ReportInsertObject`.
- Modified `DataAccess/ReportInserter.php` to use `set_post_thumbnail()` to set the featured image if an `imageId` is provided in the `ReportInsertObject`.
- Added comprehensive unit tests for the new functionality in both the API handling and data insertion logic.