### PR TITLE
feature: use datepicker in metabox for alarm time and end time

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,25 +95,6 @@ jobs:
       - name: Run integration tests
         run: composer exec phpunit -- -c phpunit-integration.xml
 
-      - name: Upload code coverage to Codecov (unit)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
-          files: ${{github.workspace}}/build/logs/clover.xml
-          flags: unit
-
-      - name: Upload code coverage to Codecov (integration)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          disable_search: true
-          files: ${{github.workspace}}/build/logs/clover-integration.xml
-          flags: integration
-
-
   test-minimum:
     runs-on: ubuntu-22.04
     needs:

--- a/src/includes/Admin/EditScreen.php
+++ b/src/includes/Admin/EditScreen.php
@@ -69,7 +69,7 @@ abstract class EditScreen
      * @param string $value Feldwert
      * @param string $placeholder Platzhalter
      */
-    protected function echoInputDateTime(string $label, string $name, string $value, $placeholder = '')
+    protected function echoInputDateTime(string $label, string $name, string $value, string $placeholder = '')
     {
         printf('<tr><td><label for="%1$s">%2$s</label></td>', esc_attr($name), esc_html($label));
         printf(

--- a/src/includes/Admin/EditScreen.php
+++ b/src/includes/Admin/EditScreen.php
@@ -62,6 +62,25 @@ abstract class EditScreen
     }
 
     /**
+     * Gibt ein DateTime-Eingabefeld für die Metabox aus
+     *
+     * @param string $label Beschriftung
+     * @param string $name Feld-ID
+     * @param string $value Feldwert
+     * @param string $placeholder Platzhalter
+     */
+    protected function echoInputDateTime(string $label, string $name, string $value, $placeholder = '')
+    {
+        printf('<tr><td><label for="%1$s">%2$s</label></td>', esc_attr($name), esc_html($label));
+        printf(
+            '<td><input type="datetime-local" id="%1$s" name="%1$s" value="%2$s" placeholder="%3$s" /></td></tr>',
+            esc_attr($name),
+            esc_attr($value),
+            esc_attr($placeholder)
+        );
+    }
+
+    /**
      * @param WP_Term[] $terms
      * @param WP_Taxonomy $taxonomy
      * @param int[] $assignedIds

--- a/src/includes/Admin/ReportEditScreen.php
+++ b/src/includes/Admin/ReportEditScreen.php
@@ -185,17 +185,17 @@ class ReportEditScreen extends EditScreen
             );
         }
 
-        $this->echoInputText(
+        $this->echoInputDateTime(
             __('Alarm time', 'einsatzverwaltung'),
             'einsatzverwaltung_alarmzeit',
-            esc_attr($alarmzeit->format('Y-m-d H:i')),
+            esc_attr($alarmzeit->format('Y-m-d\TH:i')),
             'YYYY-MM-DD hh:mm'
         );
 
-        $this->echoInputText(
+        $this->echoInputDateTime(
             __('End time', 'einsatzverwaltung'),
             'einsatz_einsatzende',
-            esc_attr($einsatzende),
+            esc_attr(str_replace(' ', 'T', $einsatzende)),
             'YYYY-MM-DD hh:mm'
         );
 

--- a/src/includes/Types/Report.php
+++ b/src/includes/Types/Report.php
@@ -287,6 +287,7 @@ class Report implements CustomPostType
     {
         $sanitizedValue = sanitize_text_field($value);
         if (!empty($sanitizedValue)) {
+            $sanitizedValue = str_replace('T', ' ', $sanitizedValue);
             $dateTime = date_create($sanitizedValue);
         }
 

--- a/src/js/einsatzverwaltung-edit.js
+++ b/src/js/einsatzverwaltung-edit.js
@@ -1,7 +1,7 @@
 const { __ } = wp.i18n;
 
 jQuery(function () {
-    const datumsregex = /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):([0-5][0-9])$/;
+    const datumsregex = /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9])$/;
     const hinweistext = __('Please use the following format: YYYY-MM-DD hh:mm', 'einsatzverwaltung');
 
     jQuery('#einsatzverwaltung_alarmzeit').after('&nbsp;<span class="einsatzverwaltung_hint" id="einsatzverwaltung_alarmzeit_hint"></span>');

--- a/tests/unit/Types/ReportTest.php
+++ b/tests/unit/Types/ReportTest.php
@@ -69,4 +69,13 @@ class ReportTest extends UnitTestCase
         $registrationArgs = (new Report())->getRegistrationArgs();
         $this->assertContainsEquals('excerpt', $registrationArgs['supports']);
     }
+
+    public function testSanitizeTimeOfEnding()
+    {
+        $report = new Report();
+        $this->assertEquals('2021-08-29 21:34', $report->sanitizeTimeOfEnding('2021-08-29 21:34'));
+        $this->assertEquals('2021-08-29 21:34', $report->sanitizeTimeOfEnding('2021-08-29T21:34'));
+        $this->assertEquals('', $report->sanitizeTimeOfEnding('invalid'));
+        $this->assertEquals('', $report->sanitizeTimeOfEnding(''));
+    }
 }


### PR DESCRIPTION
Hi Andreas (@abrain), 
ich habe hier einmal ein kleines "Feature" - ein Date-Picker anstatt des plain-text Feldes für die Auswahl der Alarm- und Endzeit.

In Zukunft werde ich vermutlich häufiger mal contributen! ;)

Diese Changes setzen #272 um.